### PR TITLE
Support for RN 0.56 and new Google Play rules (target SDK 26)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 23
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         ndk {
@@ -26,6 +26,7 @@ dependencies {
     compile 'com.facebook.react:react-native:+'
     compile 'com.google.android.gms:play-services-gcm:9.4.0'
     compile 'com.google.firebase:firebase-messaging:9.4.0'
+    compile 'com.android.support:appcompat-v7:26.0.+'
     compile 'com.microsoft.azure:notification-hubs-android-sdk:0.4@aar'
     compile 'com.microsoft.azure:azure-notifications-handler:1.0.1@aar'
 }

--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeNotificationsHandler.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeNotificationsHandler.java
@@ -3,6 +3,7 @@ package com.azure.reactnative.notificationhub;
 import android.app.AlarmManager;
 import android.app.Application;
 import android.app.Notification;
+import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
@@ -32,7 +33,7 @@ import java.util.Set;
 
 public class ReactNativeNotificationsHandler extends NotificationsHandler {
     public static final String TAG = "ReactNativeNotificationsHandler";
-
+    private static final String NOTIFICATION_CHANNEL_ID = "rn-push-notification-channel-id";
     private static final long DEFAULT_VIBRATION = 300L;
 
     private Context context;
@@ -102,7 +103,7 @@ public class ReactNativeNotificationsHandler extends NotificationsHandler {
                 title = context.getPackageManager().getApplicationLabel(appInfo).toString();
             }
 
-            NotificationCompat.Builder notification = new NotificationCompat.Builder(context)
+            NotificationCompat.Builder notification = new NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ID)
                     .setContentTitle(title)
                     .setTicker(bundle.getString("ticker"))
                     .setVisibility(NotificationCompat.VISIBILITY_PRIVATE)
@@ -217,6 +218,7 @@ public class ReactNativeNotificationsHandler extends NotificationsHandler {
                     PendingIntent.FLAG_UPDATE_CURRENT);
 
             NotificationManager notificationManager = notificationManager();
+            checkOrCreateChannel(notificationManager);
 
             notification.setContentIntent(pendingIntent);
 
@@ -275,5 +277,22 @@ public class ReactNativeNotificationsHandler extends NotificationsHandler {
 
     private NotificationManager notificationManager() {
         return (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+    }
+
+    private static boolean channelCreated = false;
+    private static void checkOrCreateChannel(NotificationManager manager) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
+            return;
+        if (channelCreated)
+            return;
+        if (manager == null)
+            return;
+         final CharSequence name = "rn-push-notification-channel";
+        int importance = NotificationManager.IMPORTANCE_DEFAULT;
+        NotificationChannel channel = new NotificationChannel(NOTIFICATION_CHANNEL_ID, name, importance);
+        channel.enableLights(true);
+        channel.enableVibration(true);
+        manager.createNotificationChannel(channel);
+        channelCreated = true;
     }
 }


### PR DESCRIPTION
Fixes notifications on Android 8.0+ (SDK 26) with implementing NotificationChannel.
Also updated to target SDK 26 according with new Google Play requirement.

> Google Play [will require](https://support.google.com/googleplay/android-developer/answer/113469#targetsdk) that new apps target at least Android 8.0 (API level 26) from August 1, 2018, and that app updates target Android 8.0 from November 1, 2018.