### PR TITLE
updates dependencies to match sdk 26. fixes #53

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,9 +24,9 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.facebook.react:react-native:+'
-    compile 'com.google.android.gms:play-services-gcm:9.4.0'
-    compile 'com.google.firebase:firebase-messaging:9.4.0'
-    compile 'com.android.support:appcompat-v7:26.0.+'
+    compile 'com.google.android.gms:play-services-gcm:15.0.0'
+    compile 'com.google.firebase:firebase-messaging:15.0.0'
+    compile 'com.android.support:appcompat-v7:26.1.0'
     compile 'com.microsoft.azure:notification-hubs-android-sdk:0.4@aar'
     compile 'com.microsoft.azure:azure-notifications-handler:1.0.1@aar'
 }


### PR DESCRIPTION
I had the same issue stated in #53 and it occurs due to outdated dependencies of play-services-gcm  and firebase-messaging. It seems that these packages use support packages from 23.x and this causes the project to be compiled with sdk 23, where the corresponding method signatore for `NotificationCompat.Builder(context, channelId)` does not exist.