### PR TITLE
uses “google.message_id” instead of “id”

### DIFF
--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeNotificationsHandler.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeNotificationsHandler.java
@@ -99,7 +99,7 @@ public class ReactNativeNotificationsHandler extends NotificationsHandler {
                 return;
             }
 
-            String notificationIdString = bundle.getString("id");
+            String notificationIdString = bundle.getString("google.message_id");
             if (notificationIdString == null) {
                 Log.e(TAG, "No notification ID specified for the notification");
                 return;
@@ -223,7 +223,7 @@ public class ReactNativeNotificationsHandler extends NotificationsHandler {
                 }
             }
 
-            int notificationID = Integer.parseInt(notificationIdString);
+            int notificationID = notificationIdString.hashCode();
 
             PendingIntent pendingIntent = PendingIntent.getActivity(context, notificationID, intent,
                     PendingIntent.FLAG_UPDATE_CURRENT);


### PR DESCRIPTION
Currently when receiving notifications on android, it will just crash because `bundle.getString("id")` does not exist any more. I'm not sure why, but I guess it has been removed during the deprecation of GCM. However, the notification id is now stored unter `google.mesage_id`.

This PR fixes this issue on android