### PR TITLE
[fix] no notification in tray when app in foreground (like firebase)

### DIFF
--- a/android/src/main/java/com/azure/reactnative/notificationhub/NotificationHubUtil.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/NotificationHubUtil.java
@@ -25,6 +25,8 @@ public class NotificationHubUtil {
     private static final String KEY_FOR_PREFS_CHANNELENABLELIGHTS = "AzureNotificationHub_channelEnableLights";
     private static final String KEY_FOR_PREFS_CHANNELENABLEVIBRATION = "AzureNotificationHub_channelEnableVibration";
 
+    private boolean mIsForeground;
+
     public static NotificationHubUtil getInstance() {
         if (sharedNotificationHubUtilInstance == null) {
             sharedNotificationHubUtilInstance = new NotificationHubUtil();
@@ -128,6 +130,14 @@ public class NotificationHubUtil {
 
     public boolean hasChannelEnableVibration(Context context) {
         return hasKey(context, KEY_FOR_PREFS_CHANNELENABLEVIBRATION);
+    }
+
+    public void setAppIsForeground(boolean isForeground) {
+        mIsForeground = isForeground;
+    }
+
+    public boolean getAppIsForeground() {
+        return mIsForeground;
     }
 
     public NotificationHub createNotificationHub(String hubName, String connectionString, ReactContext reactContext) {

--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeFirebaseMessagingService.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeFirebaseMessagingService.java
@@ -58,6 +58,7 @@ public class ReactNativeFirebaseMessagingService extends FirebaseMessagingServic
 
     @Override
     public void onMessageReceived(RemoteMessage remoteMessage) {
+        NotificationHubUtil notificationHubUtil = NotificationHubUtil.getInstance();
         Log.d(TAG, "Remote message from: " + remoteMessage.getFrom());
 
         if (notificationChannelID == null) {
@@ -65,7 +66,13 @@ public class ReactNativeFirebaseMessagingService extends FirebaseMessagingServic
         }
 
         Bundle bundle = remoteMessage.toIntent().getExtras();
-        ReactNativeNotificationsHandler.sendNotification(this, bundle, notificationChannelID);
+        if (notificationHubUtil.getAppIsForeground()) {
+            bundle.putBoolean("foreground", true);
+            bundle.putBoolean("userInteraction", false);
+            bundle.putBoolean("coldstart", false);
+        } else {
+            ReactNativeNotificationsHandler.sendNotification(this, bundle, notificationChannelID);
+        }
         ReactNativeNotificationsHandler.sendBroadcast(this, bundle, 0);
     }
 }

--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeNotificationHubModule.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeNotificationHubModule.java
@@ -49,7 +49,6 @@ public class ReactNativeNotificationHubModule extends ReactContextBaseJavaModule
 
     private ReactApplicationContext mReactContext;
     private LocalBroadcastReceiver mLocalBroadcastReceiver;
-    private boolean mIsForeground;
 
     public ReactNativeNotificationHubModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -65,6 +64,16 @@ public class ReactNativeNotificationHubModule extends ReactContextBaseJavaModule
     @Override
     public String getName() {
         return AZURE_NOTIFICATION_HUB_NAME;
+    }
+
+    public void setIsForeground(boolean isForeground) {
+        NotificationHubUtil notificationHubUtil = NotificationHubUtil.getInstance();
+        notificationHubUtil.setAppIsForeground(isForeground);
+    }
+
+    public boolean getIsForeground() {
+        NotificationHubUtil notificationHubUtil = NotificationHubUtil.getInstance();
+        return notificationHubUtil.getAppIsForeground();
     }
 
     @ReactMethod
@@ -168,7 +177,8 @@ public class ReactNativeNotificationHubModule extends ReactContextBaseJavaModule
 
     @Override
     public void onHostResume() {
-        mIsForeground = true;
+        setIsForeground(true);
+
         Activity activity = getCurrentActivity();
         if (activity != null) {
             Intent intent = activity.getIntent();
@@ -188,7 +198,7 @@ public class ReactNativeNotificationHubModule extends ReactContextBaseJavaModule
 
     @Override
     public void onHostPause() {
-        mIsForeground = false;
+        setIsForeground(false);
     }
 
     @Override
@@ -213,7 +223,7 @@ public class ReactNativeNotificationHubModule extends ReactContextBaseJavaModule
     public class LocalBroadcastReceiver extends BroadcastReceiver {
         @Override
         public void onReceive(Context context, Intent intent) {
-            if (mIsForeground) {
+            if (getIsForeground()) {
                 String event = intent.getStringExtra("event");
                 String data = intent.getStringExtra("data");
                 mReactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)


### PR DESCRIPTION
Normally push notifications don't appear in the tray when the app is in foreground.
Like done here: https://github.com/invertase/react-native-firebase/blob/3582e4865f5da49ba8b70b8681a03b7ba372aa51/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingService.java#L60