### PR TITLE
Improvements, bug fixes and release 0.9.4

### DIFF
--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeConstants.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeConstants.java
@@ -10,6 +10,13 @@ public final class ReactNativeConstants {
     public static final String EVENT_AZURE_NOTIFICATION_HUB_REGISTERED = "azureNotificationHubRegistered";
     public static final String EVENT_AZURE_NOTIFICATION_HUB_REGISTERED_ERROR = "azureNotificationHubRegisteredError";
 
+    // Registration's keys
+    public static final String KEY_REGISTRATION_CHANNELNAME = "channelName";
+    public static final String KEY_REGISTRATION_CHANNELIMPORTANCE = "channelImportance";
+    public static final String KEY_REGISTRATION_CHANNELSHOWBADGE = "channelShowBadge";
+    public static final String KEY_REGISTRATION_CHANNELENABLELIGHTS = "channelEnableLights";
+    public static final String KEY_REGISTRATION_CHANNELENABLEVIBRATION = "channelEnableVibration";
+
     // Shared prefs used in NotificationHubUtil
     public static final String SHARED_PREFS_NAME = "com.azure.reactnative.notificationhub.NotificationHubUtil";
     public static final String KEY_FOR_PREFS_REGISTRATIONID = "AzureNotificationHub_registrationID";
@@ -18,6 +25,7 @@ public final class ReactNativeConstants {
     public static final String KEY_FOR_PREFS_FCMTOKEN = "AzureNotificationHub_FCMToken";
     public static final String KEY_FOR_PREFS_TAGS = "AzureNotificationHub_Tags";
     public static final String KEY_FOR_PREFS_SENDERID = "AzureNotificationHub_senderID";
+    public static final String KEY_FOR_PREFS_CHANNELNAME = "AzureNotificationHub_channelName";
     public static final String KEY_FOR_PREFS_CHANNELIMPORTANCE = "AzureNotificationHub_channelImportance";
     public static final String KEY_FOR_PREFS_CHANNELSHOWBADGE = "AzureNotificationHub_channelShowBadge";
     public static final String KEY_FOR_PREFS_CHANNELENABLELIGHTS = "AzureNotificationHub_channelEnableLights";

--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeConstants.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeConstants.java
@@ -4,6 +4,8 @@ public final class ReactNativeConstants {
     // Notification
     public static final String AZURE_NOTIFICATION_HUB_NAME = "AzureNotificationHub";
     public static final String NOTIFICATION_CHANNEL_ID = "rn-push-notification-channel-id";
+    public static final String KEY_NOTIFICATION_PAYLOAD_TYPE = "notification";
+    public static final String KEY_DATA_PAYLOAD_TYPE = "data";
 
     // Notification hub events
     public static final String EVENT_REMOTE_NOTIFICATION_RECEIVED = "remoteNotificationReceived";
@@ -37,6 +39,7 @@ public final class ReactNativeConstants {
 
     // Remote notification payload
     public static final String KEY_REMOTE_NOTIFICATION_MESSAGE = "message";
+    public static final String KEY_REMOTE_NOTIFICATION_BODY = "body";
     public static final String KEY_REMOTE_NOTIFICATION_ID = "google.message_id";
     public static final String KEY_REMOTE_NOTIFICATION_TITLE = "title";
     public static final String KEY_REMOTE_NOTIFICATION_PRIORITY = "google.original_priority";
@@ -69,7 +72,6 @@ public final class ReactNativeConstants {
     public static final String REMOTE_NOTIFICATION_PRIORITY_NORMAL = "normal";
 
     // Intent
-    public static final String KEY_INTENT_NOTIFICATION = "notification";
     public static final String KEY_INTENT_EVENT_NAME = "eventName";
     public static final String KEY_INTENT_EVENT_TYPE = "eventType";
     public static final String KEY_INTENT_EVENT_STRING_DATA = "eventStringData";
@@ -85,7 +87,6 @@ public final class ReactNativeConstants {
     // Errors
     public static final String ERROR_NO_ACTIVITY_CLASS = "No activity class found for the notification";
     public static final String ERROR_NO_MESSAGE = "No message specified for the notification";
-    public static final String ERROR_NO_NOTIF_ID = "No notification ID specified for the notification";
     public static final String ERROR_COVERT_ACTIONS = "Exception while converting actions to JSON object.";
     public static final String ERROR_GET_ACTIONS_ARRAY = "Exception while getting action from actionsArray.";
     public static final String ERROR_SEND_PUSH_NOTIFICATION = "failed to send push notification";

--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeConstants.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeConstants.java
@@ -63,6 +63,7 @@ public final class ReactNativeConstants {
     public static final String KEY_REMOTE_NOTIFICATION_TAG = "tag";
     public static final String KEY_REMOTE_NOTIFICATION_USER_INTERACTION = "userInteraction";
     public static final String KEY_REMOTE_NOTIFICATION_COLDSTART = "coldstart";
+    public static final String KEY_REMOTE_NOTIFICATION_AVATAR_URL = "avatarUrl";
 
     // Remote notification payload's priority
     public static final String REMOTE_NOTIFICATION_PRIORITY_MAX = "max";
@@ -101,6 +102,7 @@ public final class ReactNativeConstants {
     public static final String ERROR_NOTIFICATION_HUB = "E_NOTIFICATION_HUB";
     public static final String ERROR_NOT_REGISTERED = "E_NOT_REGISTERED";
     public static final String ERROR_NOT_REGISTERED_DESC = "No registration to Azure Notification Hub.";
+    public static final String ERROR_FETCH_IMAGE = "Error while fetching image.";
 
     private ReactNativeConstants() {
     }

--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeConstants.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeConstants.java
@@ -11,6 +11,10 @@ public final class ReactNativeConstants {
     public static final String EVENT_AZURE_NOTIFICATION_HUB_REGISTERED_ERROR = "azureNotificationHubRegisteredError";
 
     // Registration's keys
+    public static final String KEY_REGISTRATION_CONNECTIONSTRING = "connectionString";
+    public static final String KEY_REGISTRATION_HUBNAME = "hubName";
+    public static final String KEY_REGISTRATION_SENDERID = "senderID";
+    public static final String KEY_REGISTRATION_TAGS = "tags";
     public static final String KEY_REGISTRATION_CHANNELNAME = "channelName";
     public static final String KEY_REGISTRATION_CHANNELIMPORTANCE = "channelImportance";
     public static final String KEY_REGISTRATION_CHANNELSHOWBADGE = "channelShowBadge";

--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeConstants.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeConstants.java
@@ -3,10 +3,12 @@ package com.azure.reactnative.notificationhub;
 public final class ReactNativeConstants {
     // Notification
     public static final String AZURE_NOTIFICATION_HUB_NAME = "AzureNotificationHub";
-    public static final String NOTIF_REGISTER_AZURE_HUB_EVENT = "azureNotificationHubRegistered";
-    public static final String NOTIF_AZURE_HUB_REGISTRATION_ERROR_EVENT = "azureNotificationHubRegistrationError";
-    public static final String DEVICE_NOTIF_EVENT = "remoteNotificationReceived";
     public static final String NOTIFICATION_CHANNEL_ID = "rn-push-notification-channel-id";
+
+    // Notification hub events
+    public static final String EVENT_REMOTE_NOTIFICATION_RECEIVED = "remoteNotificationReceived";
+    public static final String EVENT_AZURE_NOTIFICATION_HUB_REGISTERED = "azureNotificationHubRegistered";
+    public static final String EVENT_AZURE_NOTIFICATION_HUB_REGISTERED_ERROR = "azureNotificationHubRegisteredError";
 
     // Shared prefs used in NotificationHubUtil
     public static final String SHARED_PREFS_NAME = "com.azure.reactnative.notificationhub.NotificationHubUtil";
@@ -54,8 +56,13 @@ public final class ReactNativeConstants {
     public static final String REMOTE_NOTIFICATION_PRIORITY_MIN = "min";
     public static final String REMOTE_NOTIFICATION_PRIORITY_NORMAL = "normal";
 
-    // Intent payload
+    // Intent
     public static final String KEY_INTENT_NOTIFICATION = "notification";
+    public static final String KEY_INTENT_EVENT_NAME = "eventName";
+    public static final String KEY_INTENT_EVENT_TYPE = "eventType";
+    public static final String KEY_INTENT_EVENT_STRING_DATA = "eventStringData";
+    public static final String INTENT_EVENT_TYPE_STRING = "eventTypeString";
+    public static final String INTENT_EVENT_TYPE_BUNDLE = "eventTypeBundle";
 
     // Resources
     public static final String RESOURCE_DEF_TYPE_MIPMAP = "mipmap";

--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeFirebaseMessagingService.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeFirebaseMessagingService.java
@@ -87,6 +87,7 @@ public class ReactNativeFirebaseMessagingService extends FirebaseMessagingServic
         } else {
             ReactNativeNotificationsHandler.sendNotification(this, bundle, notificationChannelID);
         }
+
         ReactNativeNotificationsHandler.sendBroadcast(this, bundle, 0);
     }
 }

--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeFirebaseMessagingService.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeFirebaseMessagingService.java
@@ -23,6 +23,11 @@ public class ReactNativeFirebaseMessagingService extends FirebaseMessagingServic
         if (notificationChannelID == null) {
             ReactNativeNotificationHubUtil notificationHubUtil = ReactNativeNotificationHubUtil.getInstance();
             ReactNativeNotificationChannelBuilder builder = ReactNativeNotificationChannelBuilder.Factory.create();
+
+            if (notificationHubUtil.hasChannelName(context)) {
+                builder.setName(notificationHubUtil.getChannelName(context));
+            }
+
             if (notificationHubUtil.hasChannelImportance(context)) {
                 builder.setImportance(notificationHubUtil.getChannelImportance(context));
             }

--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeFirebaseMessagingService.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeFirebaseMessagingService.java
@@ -49,8 +49,10 @@ public class ReactNativeFirebaseMessagingService extends FirebaseMessagingServic
                 NotificationChannel channel = builder.build();
                 NotificationManager notificationManager = (NotificationManager) context.getSystemService(
                         Context.NOTIFICATION_SERVICE);
-                notificationManager.createNotificationChannel(channel);
-                notificationChannelID = channel.getId();
+                if (notificationManager != null) {
+                    notificationManager.createNotificationChannel(channel);
+                    notificationChannelID = channel.getId();
+                }
             }
         }
     }

--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeNotificationHubModule.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeNotificationHubModule.java
@@ -11,7 +11,6 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.LifecycleEventListener;
-import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 
@@ -211,10 +210,7 @@ public class ReactNativeNotificationHubModule extends ReactContextBaseJavaModule
         @Override
         public void onReceive(Context context, Intent intent) {
             if (getIsForeground()) {
-                String event = intent.getStringExtra("event");
-                String data = intent.getStringExtra("data");
-                mReactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                        .emit(event, data);
+                ReactNativeUtil.emitIntent(mReactContext, intent);
             }
         }
     }

--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeNotificationHubModule.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeNotificationHubModule.java
@@ -97,23 +97,28 @@ public class ReactNativeNotificationHubModule extends ReactContextBaseJavaModule
         notificationHubUtil.setSenderID(reactContext, senderID);
         notificationHubUtil.setTags(reactContext, tags);
 
-        if (config.hasKey("channelImportance")) {
-            int channelImportance = config.getInt("channelImportance");
+        if (config.hasKey(KEY_REGISTRATION_CHANNELNAME)) {
+            String channelName = config.getString(KEY_REGISTRATION_CHANNELNAME);
+            notificationHubUtil.setChannelName(reactContext, channelName);
+        }
+
+        if (config.hasKey(KEY_REGISTRATION_CHANNELIMPORTANCE)) {
+            int channelImportance = config.getInt(KEY_REGISTRATION_CHANNELIMPORTANCE);
             notificationHubUtil.setChannelImportance(reactContext, channelImportance);
         }
 
-        if (config.hasKey("channelShowBadge")) {
-            boolean channelShowBadge = config.getBoolean("channelShowBadge");
+        if (config.hasKey(KEY_REGISTRATION_CHANNELSHOWBADGE)) {
+            boolean channelShowBadge = config.getBoolean(KEY_REGISTRATION_CHANNELSHOWBADGE);
             notificationHubUtil.setChannelShowBadge(reactContext, channelShowBadge);
         }
 
-        if (config.hasKey("channelEnableLights")) {
-            boolean channelEnableLights = config.getBoolean("channelEnableLights");
+        if (config.hasKey(KEY_REGISTRATION_CHANNELENABLELIGHTS)) {
+            boolean channelEnableLights = config.getBoolean(KEY_REGISTRATION_CHANNELENABLELIGHTS);
             notificationHubUtil.setChannelEnableLights(reactContext, channelEnableLights);
         }
 
-        if (config.hasKey("channelEnableVibration")) {
-            boolean channelEnableVibration = config.getBoolean("channelEnableVibration");
+        if (config.hasKey(KEY_REGISTRATION_CHANNELENABLEVIBRATION)) {
+            boolean channelEnableVibration = config.getBoolean(KEY_REGISTRATION_CHANNELENABLEVIBRATION);
             notificationHubUtil.setChannelEnableVibration(reactContext, channelEnableVibration);
         }
 

--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeNotificationHubModule.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeNotificationHubModule.java
@@ -64,27 +64,27 @@ public class ReactNativeNotificationHubModule extends ReactContextBaseJavaModule
     @ReactMethod
     public void register(ReadableMap config, Promise promise) {
         ReactNativeNotificationHubUtil notificationHubUtil = ReactNativeNotificationHubUtil.getInstance();
-        String connectionString = config.getString("connectionString");
+        String connectionString = config.getString(KEY_REGISTRATION_CONNECTIONSTRING);
         if (connectionString == null) {
             promise.reject(ERROR_INVALID_ARGUMENTS, ERROR_INVALID_CONNECTION_STRING);
             return;
         }
 
-        String hubName = config.getString("hubName");
+        String hubName = config.getString(KEY_REGISTRATION_HUBNAME);
         if (hubName == null) {
             promise.reject(ERROR_INVALID_ARGUMENTS, ERROR_INVALID_HUBNAME);
             return;
         }
 
-        String senderID = config.getString("senderID");
+        String senderID = config.getString(KEY_REGISTRATION_SENDERID);
         if (senderID == null) {
             promise.reject(ERROR_INVALID_ARGUMENTS, ERROR_INVALID_SENDER_ID);
             return;
         }
 
         String[] tags = null;
-        if (config.hasKey("tags") && !config.isNull("tags")) {
-            ReadableArray tagsJson = config.getArray("tags");
+        if (config.hasKey(KEY_REGISTRATION_TAGS) && !config.isNull(KEY_REGISTRATION_TAGS)) {
+            ReadableArray tagsJson = config.getArray(KEY_REGISTRATION_TAGS);
             tags = new String[tagsJson.size()];
             for (int i = 0; i < tagsJson.size(); ++i) {
                 tags[i] = tagsJson.getString(i);

--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeNotificationHubModule.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeNotificationHubModule.java
@@ -176,10 +176,7 @@ public class ReactNativeNotificationHubModule extends ReactContextBaseJavaModule
             if (intent != null) {
                 Bundle bundle = ReactNativeUtil.getBundleFromIntent(intent);
                 if (bundle != null) {
-                    if (intent.hasExtra(KEY_NOTIFICATION_PAYLOAD_TYPE)) {
-                        intent.removeExtra(KEY_NOTIFICATION_PAYLOAD_TYPE);
-                    }
-
+                    ReactNativeUtil.removeNotificationFromIntent(intent);
                     bundle.putBoolean(KEY_REMOTE_NOTIFICATION_FOREGROUND, false);
                     bundle.putBoolean(KEY_REMOTE_NOTIFICATION_USER_INTERACTION, true);
                     bundle.putBoolean(KEY_REMOTE_NOTIFICATION_COLDSTART, true);

--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeNotificationHubModule.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeNotificationHubModule.java
@@ -174,9 +174,12 @@ public class ReactNativeNotificationHubModule extends ReactContextBaseJavaModule
         if (activity != null) {
             Intent intent = activity.getIntent();
             if (intent != null) {
-                Bundle bundle = intent.getBundleExtra(KEY_INTENT_NOTIFICATION);
+                Bundle bundle = ReactNativeUtil.getBundleFromIntent(intent);
                 if (bundle != null) {
-                    intent.removeExtra(KEY_INTENT_NOTIFICATION);
+                    if (intent.hasExtra(KEY_NOTIFICATION_PAYLOAD_TYPE)) {
+                        intent.removeExtra(KEY_NOTIFICATION_PAYLOAD_TYPE);
+                    }
+
                     bundle.putBoolean(KEY_REMOTE_NOTIFICATION_FOREGROUND, false);
                     bundle.putBoolean(KEY_REMOTE_NOTIFICATION_USER_INTERACTION, true);
                     bundle.putBoolean(KEY_REMOTE_NOTIFICATION_COLDSTART, true);
@@ -198,7 +201,7 @@ public class ReactNativeNotificationHubModule extends ReactContextBaseJavaModule
 
     @Override
     public void onNewIntent(Intent intent) {
-        Bundle bundle = intent.getBundleExtra(KEY_INTENT_NOTIFICATION);
+        Bundle bundle = ReactNativeUtil.getBundleFromIntent(intent);
         if (bundle != null) {
             bundle.putBoolean(KEY_REMOTE_NOTIFICATION_FOREGROUND, false);
             bundle.putBoolean(KEY_REMOTE_NOTIFICATION_USER_INTERACTION, true);

--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeNotificationHubUtil.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeNotificationHubUtil.java
@@ -105,6 +105,18 @@ public class ReactNativeNotificationHubUtil {
         setPref(context, KEY_FOR_PREFS_SENDERID, senderID);
     }
 
+    public String getChannelName(Context context) {
+        return getPref(context, KEY_FOR_PREFS_CHANNELNAME);
+    }
+
+    public void setChannelName(Context context, String channelName) {
+        setPref(context, KEY_FOR_PREFS_CHANNELNAME, channelName);
+    }
+
+    public boolean hasChannelName(Context context) {
+        return hasKey(context, KEY_FOR_PREFS_CHANNELNAME);
+    }
+
     public int getChannelImportance(Context context) {
         return getPrefInt(context, KEY_FOR_PREFS_CHANNELIMPORTANCE);
     }

--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeNotificationsHandler.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeNotificationsHandler.java
@@ -19,8 +19,6 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import android.util.Log;
 
-import org.json.JSONObject;
-
 import static com.azure.reactnative.notificationhub.ReactNativeConstants.*;
 
 public final class ReactNativeNotificationsHandler {
@@ -28,7 +26,17 @@ public final class ReactNativeNotificationsHandler {
 
     private static final long DEFAULT_VIBRATION = 300L;
 
-    private ReactNativeNotificationsHandler() {
+    public static void sendBroadcast(final Context context, final Intent intent, final long delay) {
+        ReactNativeUtil.runInWorkerThread(new Runnable() {
+            public void run() {
+                try {
+                    Thread.currentThread().sleep(delay);
+                    LocalBroadcastManager localBroadcastManager = LocalBroadcastManager.getInstance(context);
+                    localBroadcastManager.sendBroadcast(intent);
+                } catch (Exception e) {
+                }
+            }
+        });
     }
 
     public static void sendBroadcast(final Context context, final Bundle bundle, final long delay) {
@@ -36,10 +44,9 @@ public final class ReactNativeNotificationsHandler {
             public void run() {
                 try {
                     Thread.currentThread().sleep(delay);
-                    JSONObject json = ReactNativeUtil.convertBundleToJSON(bundle);
-                    Intent event = ReactNativeUtil.createBroadcastIntent(TAG, json);
+                    Intent intent = ReactNativeUtil.createBroadcastIntent(TAG, bundle);
                     LocalBroadcastManager localBroadcastManager = LocalBroadcastManager.getInstance(context);
-                    localBroadcastManager.sendBroadcast(event);
+                    localBroadcastManager.sendBroadcast(intent);
                 } catch (Exception e) {
                 }
             }
@@ -170,5 +177,8 @@ public final class ReactNativeNotificationsHandler {
         } catch (Exception e) {
             Log.e(TAG, ERROR_SEND_PUSH_NOTIFICATION, e);
         }
+    }
+
+    private ReactNativeNotificationsHandler() {
     }
 }

--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeRegistrationIntentService.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeRegistrationIntentService.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.content.Intent;
 
 import androidx.core.app.JobIntentService;
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import android.util.Log;
 
@@ -33,7 +32,6 @@ public class ReactNativeRegistrationIntentService extends JobIntentService {
 
     @Override
     protected void onHandleWork(Intent intent) {
-        final LocalBroadcastManager localBroadcastManager = LocalBroadcastManager.getInstance(this);
         final Intent event = ReactNativeNotificationHubUtil.IntentFactory.createIntent(TAG);
         final ReactNativeNotificationHubUtil notificationHubUtil = ReactNativeNotificationHubUtil.getInstance();
         final String connectionString = notificationHubUtil.getConnectionString(this);
@@ -71,9 +69,16 @@ public class ReactNativeRegistrationIntentService extends JobIntentService {
                                 notificationHubUtil.setRegistrationID(ReactNativeRegistrationIntentService.this, regID);
                                 notificationHubUtil.setFCMToken(ReactNativeRegistrationIntentService.this, token);
 
-                                event.putExtra("event", ReactNativeConstants.NOTIF_REGISTER_AZURE_HUB_EVENT);
-                                event.putExtra("data", regID);
-                                localBroadcastManager.sendBroadcast(event);
+                                event.putExtra(
+                                        ReactNativeConstants.KEY_INTENT_EVENT_NAME,
+                                        ReactNativeConstants.EVENT_AZURE_NOTIFICATION_HUB_REGISTERED);
+                                event.putExtra(
+                                        ReactNativeConstants.KEY_INTENT_EVENT_TYPE,
+                                        ReactNativeConstants.INTENT_EVENT_TYPE_STRING);
+                                event.putExtra(
+                                        ReactNativeConstants.KEY_INTENT_EVENT_STRING_DATA, regID);
+                                ReactNativeNotificationsHandler.sendBroadcast(
+                                        ReactNativeRegistrationIntentService.this, event, 0);
 
                                 // Create notification handler
                                 ReactNativeFirebaseMessagingService.createNotificationChannel(
@@ -82,9 +87,15 @@ public class ReactNativeRegistrationIntentService extends JobIntentService {
                         } catch (Exception e) {
                             Log.e(TAG, "Failed to complete token refresh", e);
 
-                            event.putExtra("event", ReactNativeConstants.NOTIF_AZURE_HUB_REGISTRATION_ERROR_EVENT);
-                            event.putExtra("data", e.getMessage());
-                            localBroadcastManager.sendBroadcast(event);
+                            event.putExtra(
+                                    ReactNativeConstants.KEY_INTENT_EVENT_NAME,
+                                    ReactNativeConstants.EVENT_AZURE_NOTIFICATION_HUB_REGISTERED_ERROR);
+                            event.putExtra(
+                                    ReactNativeConstants.KEY_INTENT_EVENT_TYPE,
+                                    ReactNativeConstants.INTENT_EVENT_TYPE_STRING);
+                            event.putExtra(ReactNativeConstants.KEY_INTENT_EVENT_STRING_DATA, e.getMessage());
+                            ReactNativeNotificationsHandler.sendBroadcast(
+                                    ReactNativeRegistrationIntentService.this, event, 0);
                         }
                     }
                 });

--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeUtil.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeUtil.java
@@ -85,6 +85,8 @@ public final class ReactNativeUtil {
                     map.putInt(key, ((Short) o).intValue());
                 } else if (o instanceof Byte) {
                     map.putInt(key, ((Byte) o).intValue());
+                } else if (o instanceof Boolean) {
+                    map.putBoolean(key, (Boolean) o);
                 } else {
                     map.putNull(key);
                 }

--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeUtil.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeUtil.java
@@ -4,6 +4,8 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Bundle;
@@ -22,7 +24,10 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.lang.invoke.WrongMethodTypeException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -32,7 +37,7 @@ import static com.azure.reactnative.notificationhub.ReactNativeConstants.*;
 public final class ReactNativeUtil {
     public static final String TAG = "ReactNativeUtil";
 
-    private static final ExecutorService mPool = Executors.newFixedThreadPool(1);
+    private static final ExecutorService mPool = Executors.newFixedThreadPool(2);
 
     public static void runInWorkerThread(Runnable runnable) {
         mPool.execute(runnable);
@@ -299,8 +304,35 @@ public final class ReactNativeUtil {
         return bundle;
     }
 
+    public static void removeNotificationFromIntent(Intent intent) {
+        if (intent.hasExtra(KEY_NOTIFICATION_PAYLOAD_TYPE)) {
+            intent.removeExtra(KEY_NOTIFICATION_PAYLOAD_TYPE);
+        } else if (intent.hasExtra(KEY_REMOTE_NOTIFICATION_ID)) {
+            intent.removeExtra(KEY_REMOTE_NOTIFICATION_ID);
+        }
+    }
+
     public static NotificationCompat.BigTextStyle getBigTextStyle(String bigText) {
         return new NotificationCompat.BigTextStyle().bigText(bigText);
+    }
+
+    public static class UrlWrapper {
+        public static HttpURLConnection openConnection(String url) throws Exception {
+            return (HttpURLConnection)(new URL(url)).openConnection();
+        }
+    }
+
+    public static Bitmap fetchImage(String urlString) {
+        try {
+            HttpURLConnection connection = UrlWrapper.openConnection(urlString);
+            connection.setDoInput(true);
+            connection.connect();
+            InputStream input = connection.getInputStream();
+            return BitmapFactory.decodeStream(input);
+        } catch (Exception e) {
+            Log.e(TAG, ERROR_FETCH_IMAGE, e);
+            return null;
+        }
     }
 
     private ReactNativeUtil() {

--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeUtil.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeUtil.java
@@ -229,7 +229,7 @@ public final class ReactNativeUtil {
         bundle.putBoolean(KEY_REMOTE_NOTIFICATION_FOREGROUND, true);
         bundle.putBoolean(KEY_REMOTE_NOTIFICATION_USER_INTERACTION, false);
         bundle.putBoolean(KEY_REMOTE_NOTIFICATION_COLDSTART, false);
-        intent.putExtra(KEY_INTENT_NOTIFICATION, bundle);
+        intent.putExtra(KEY_NOTIFICATION_PAYLOAD_TYPE, bundle);
 
         return intent;
     }
@@ -263,7 +263,7 @@ public final class ReactNativeUtil {
                 actionIntent.setAction(context.getPackageName() + "." + action);
                 // Add "action" for later identifying which button gets pressed.
                 bundle.putString(KEY_REMOTE_NOTIFICATION_ACTION, action);
-                actionIntent.putExtra(KEY_INTENT_NOTIFICATION, bundle);
+                actionIntent.putExtra(KEY_NOTIFICATION_PAYLOAD_TYPE, bundle);
                 PendingIntent pendingActionIntent = PendingIntent.getBroadcast(context, notificationID, actionIntent,
                         PendingIntent.FLAG_UPDATE_CURRENT);
                 notification.addAction(icon, action, pendingActionIntent);
@@ -286,6 +286,21 @@ public final class ReactNativeUtil {
                 .setAutoCancel(autoCancel);
 
         return notificationBuilder;
+    }
+
+    public static Bundle getBundleFromIntent(Intent intent) {
+        Bundle bundle = null;
+        if (intent.hasExtra(KEY_NOTIFICATION_PAYLOAD_TYPE)) {
+            bundle = intent.getBundleExtra(KEY_NOTIFICATION_PAYLOAD_TYPE);
+        } else if (intent.hasExtra(KEY_REMOTE_NOTIFICATION_ID)) {
+            bundle = intent.getExtras();
+        }
+
+        return bundle;
+    }
+
+    public static NotificationCompat.BigTextStyle getBigTextStyle(String bigText) {
+        return new NotificationCompat.BigTextStyle().bigText(bigText);
     }
 
     private ReactNativeUtil() {

--- a/docs/android-installation.md
+++ b/docs/android-installation.md
@@ -120,6 +120,11 @@ In `android/app/src/main/AndroidManifest.xml`
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
+
+        <activity
+          android:launchMode="singleTop"
+          ...>
+        </activity>
     ...
 ```
 

--- a/docs/android-installation.md
+++ b/docs/android-installation.md
@@ -189,6 +189,7 @@ const connectionString = '...';       // The Notification Hub connection string
 const hubName = '...';                // The Notification Hub name
 const senderID = '...';               // The Sender ID from the Cloud Messaging tab of the Firebase console
 const tags = [ ... ];                 // The set of tags to subscribe to
+const channelName = '...';            // The channel's name
 const channelImportance = 3;          // The channel's importance (NotificationManager.IMPORTANCE_DEFAULT = 3)
                                       // Notes:
                                       //   1. Setting this value to 4 enables heads-up notification on Android 8
@@ -213,6 +214,7 @@ export default class App extends Component {
       hubName,
       senderID,
       tags,
+      channelName,
       channelImportance,
       channelShowBadge,
       channelEnableLights,

--- a/docs/android-installation.md
+++ b/docs/android-installation.md
@@ -181,9 +181,9 @@ import {
 const NotificationHub = require('react-native-azurenotificationhub');
 const PushNotificationEmitter = new NativeEventEmitter(NotificationHub);
 
-const NOTIF_REGISTER_AZURE_HUB_EVENT = 'azureNotificationHubRegistered';
-const NOTIF_AZURE_HUB_REGISTRATION_ERROR_EVENT = 'azureNotificationHubRegistrationError';
-const DEVICE_NOTIF_EVENT = 'remoteNotificationReceived';
+const EVENT_AZURE_NOTIFICATION_HUB_REGISTERED           = 'azureNotificationHubRegistered';
+const EVENT_AZURE_NOTIFICATION_HUB_REGISTERED_ERROR     = 'azureNotificationHubRegisteredError';
+const EVENT_REMOTE_NOTIFICATION_RECEIVED                = 'remoteNotificationReceived';
 
 const connectionString = '...';       // The Notification Hub connection string
 const hubName = '...';                // The Notification Hub name
@@ -201,12 +201,12 @@ const channelEnableVibration = true;
 export default class App extends Component {
   constructor(props) {
     super(props);
-    PushNotificationEmitter.addListener(DEVICE_NOTIF_EVENT, this._onRemoteNotification);
+    PushNotificationEmitter.addListener(EVENT_REMOTE_NOTIFICATION_RECEIVED, this._onRemoteNotification);
   }
 
   register() {
-    PushNotificationEmitter.addListener(NOTIF_REGISTER_AZURE_HUB_EVENT, this._onAzureNotificationHubRegistered);
-    PushNotificationEmitter.addListener(NOTIF_AZURE_HUB_REGISTRATION_ERROR_EVENT, this._onAzureNotificationHubRegistrationError);
+    PushNotificationEmitter.addListener(EVENT_AZURE_NOTIFICATION_HUB_REGISTERED, this._onAzureNotificationHubRegistered);
+    PushNotificationEmitter.addListener(EVENT_AZURE_NOTIFICATION_HUB_REGISTERED_ERROR, this._onAzureNotificationHubRegisteredError);
   
     NotificationHub.register({
       connectionString,
@@ -251,13 +251,12 @@ export default class App extends Component {
     console.warn('RegistrationID: ' + registrationID);
   }
   
-  _onAzureNotificationHubRegistrationError(error) {
+  _onAzureNotificationHubRegisteredError(error) {
     console.warn('Error: ' + error);
   }
   
   _onRemoteNotification(notification) {
-    // Note notification will be a JSON string for android
-    console.warn('Notification received: ' + notification);
+    console.warn(notification);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-azurenotificationhub",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "React Native module to support Azure Notification Hub push notifications on Android, iOS, and Windows.",
   "main": "index.js",
   "repository": {

--- a/sample/android/app/src/main/AndroidManifest.xml
+++ b/sample/android/app/src/main/AndroidManifest.xml
@@ -32,6 +32,7 @@
         android:name=".MainActivity"
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+        android:launchMode="singleTop"
         android:windowSoftInputMode="adjustResize">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />

--- a/sample/android/app/src/test/java/com/reactnativeazurenotificationhubsample/ReactNativeFirebaseMessagingServiceTest.java
+++ b/sample/android/app/src/test/java/com/reactnativeazurenotificationhubsample/ReactNativeFirebaseMessagingServiceTest.java
@@ -30,6 +30,7 @@ import static com.azure.reactnative.notificationhub.ReactNativeConstants.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -99,6 +100,7 @@ public class ReactNativeFirebaseMessagingServiceTest {
 
         ReactNativeNotificationChannelBuilder builder = PowerMockito.mock(ReactNativeNotificationChannelBuilder.class);
         when(ReactNativeNotificationChannelBuilder.Factory.create()).thenReturn(builder);
+        when(mHubUtil.hasChannelName(mReactApplicationContext)).thenReturn(false);
         when(mHubUtil.hasChannelImportance(mReactApplicationContext)).thenReturn(false);
         when(mHubUtil.hasChannelShowBadge(mReactApplicationContext)).thenReturn(false);
         when(mHubUtil.hasChannelEnableLights(mReactApplicationContext)).thenReturn(false);
@@ -107,6 +109,7 @@ public class ReactNativeFirebaseMessagingServiceTest {
 
         ReactNativeFirebaseMessagingService.createNotificationChannel(mReactApplicationContext);
 
+        verify(builder, times(0)).setName(anyString());
         verify(builder, times(0)).setImportance(anyInt());
         verify(builder, times(0)).setShowBadge(anyBoolean());
         verify(builder, times(0)).enableLights(anyBoolean());
@@ -118,6 +121,7 @@ public class ReactNativeFirebaseMessagingServiceTest {
 
     @Test
     public void testCreateNotificationChannel() {
+        final String channelName = "Channel Name";
         final int channelImportance = 1;
         final boolean channelShowBadge = true;
         final boolean channelEnableLights = true;
@@ -129,6 +133,8 @@ public class ReactNativeFirebaseMessagingServiceTest {
         NotificationChannel channel = PowerMockito.mock(NotificationChannel.class);
         when(channel.getId()).thenReturn(NOTIFICATION_CHANNEL_ID);
         when(builder.build()).thenReturn(channel);
+        when(mHubUtil.hasChannelName(mReactApplicationContext)).thenReturn(true);
+        when(mHubUtil.getChannelName(mReactApplicationContext)).thenReturn(channelName);
         when(mHubUtil.hasChannelImportance(mReactApplicationContext)).thenReturn(true);
         when(mHubUtil.getChannelImportance(mReactApplicationContext)).thenReturn(channelImportance);
         when(mHubUtil.hasChannelShowBadge(mReactApplicationContext)).thenReturn(true);
@@ -141,6 +147,8 @@ public class ReactNativeFirebaseMessagingServiceTest {
 
         ReactNativeFirebaseMessagingService.createNotificationChannel(mReactApplicationContext);
 
+        verify(mHubUtil, times(1)).hasChannelName(mReactApplicationContext);
+        verify(builder, times(1)).setName(channelName);
         verify(mHubUtil, times(1)).hasChannelImportance(mReactApplicationContext);
         verify(builder, times(1)).setImportance(channelImportance);
         verify(mHubUtil, times(1)).hasChannelShowBadge(mReactApplicationContext);

--- a/sample/android/app/src/test/java/com/reactnativeazurenotificationhubsample/ReactNativeNotificationHubModuleTest.java
+++ b/sample/android/app/src/test/java/com/reactnativeazurenotificationhubsample/ReactNativeNotificationHubModuleTest.java
@@ -173,6 +173,22 @@ public class ReactNativeNotificationHubModuleTest {
     }
 
     @Test
+    public void testRegisterHasChannelName() {
+        final String channelName = "Channel Name";
+
+        when(mConfig.getString("connectionString")).thenReturn("connectionString");
+        when(mConfig.getString("hubName")).thenReturn("hubName");
+        when(mConfig.getString("senderID")).thenReturn("senderID");
+        when(mConfig.hasKey(KEY_REGISTRATION_CHANNELNAME)).thenReturn(true);
+        when(mConfig.getString(KEY_REGISTRATION_CHANNELNAME)).thenReturn(channelName);
+
+        mHubModule.register(mConfig, mPromise);
+
+        verify(mNotificationHubUtil, times(1)).setChannelName(
+                any(ReactContext.class), eq(channelName));
+    }
+
+    @Test
     public void testRegisterHasChannelImportance() {
         final int channelImportance = 1;
 

--- a/sample/android/app/src/test/java/com/reactnativeazurenotificationhubsample/ReactNativeNotificationHubModuleTest.java
+++ b/sample/android/app/src/test/java/com/reactnativeazurenotificationhubsample/ReactNativeNotificationHubModuleTest.java
@@ -149,7 +149,7 @@ public class ReactNativeNotificationHubModuleTest {
 
     @Test
     public void testRegisterMissingHubName() {
-        when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn(KEY_REGISTRATION_CONNECTIONSTRING);
+        when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn("Connection String");
         when(mConfig.getString(KEY_REGISTRATION_HUBNAME)).thenReturn(null);
 
         mHubModule.register(mConfig, mPromise);
@@ -161,8 +161,8 @@ public class ReactNativeNotificationHubModuleTest {
 
     @Test
     public void testRegisterMissingSenderID() {
-        when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn(KEY_REGISTRATION_CONNECTIONSTRING);
-        when(mConfig.getString(KEY_REGISTRATION_HUBNAME)).thenReturn(KEY_REGISTRATION_HUBNAME);
+        when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn("Connection String");
+        when(mConfig.getString(KEY_REGISTRATION_HUBNAME)).thenReturn("Hub Name");
         when(mConfig.getString(KEY_REGISTRATION_SENDERID)).thenReturn(null);
 
         mHubModule.register(mConfig, mPromise);
@@ -176,9 +176,9 @@ public class ReactNativeNotificationHubModuleTest {
     public void testRegisterHasChannelName() {
         final String channelName = "Channel Name";
 
-        when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn(KEY_REGISTRATION_CONNECTIONSTRING);
-        when(mConfig.getString(KEY_REGISTRATION_HUBNAME)).thenReturn(KEY_REGISTRATION_HUBNAME);
-        when(mConfig.getString(KEY_REGISTRATION_SENDERID)).thenReturn(KEY_REGISTRATION_SENDERID);
+        when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn("Connection String");
+        when(mConfig.getString(KEY_REGISTRATION_HUBNAME)).thenReturn("Hub Name");
+        when(mConfig.getString(KEY_REGISTRATION_SENDERID)).thenReturn("Sender ID");
         when(mConfig.hasKey(KEY_REGISTRATION_CHANNELNAME)).thenReturn(true);
         when(mConfig.getString(KEY_REGISTRATION_CHANNELNAME)).thenReturn(channelName);
 
@@ -195,8 +195,8 @@ public class ReactNativeNotificationHubModuleTest {
         when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn(KEY_REGISTRATION_CONNECTIONSTRING);
         when(mConfig.getString(KEY_REGISTRATION_HUBNAME)).thenReturn(KEY_REGISTRATION_HUBNAME);
         when(mConfig.getString(KEY_REGISTRATION_SENDERID)).thenReturn(KEY_REGISTRATION_SENDERID);
-        when(mConfig.hasKey("channelImportance")).thenReturn(true);
-        when(mConfig.getInt("channelImportance")).thenReturn(channelImportance);
+        when(mConfig.hasKey(KEY_REGISTRATION_CHANNELIMPORTANCE)).thenReturn(true);
+        when(mConfig.getInt(KEY_REGISTRATION_CHANNELIMPORTANCE)).thenReturn(channelImportance);
 
         mHubModule.register(mConfig, mPromise);
 
@@ -211,8 +211,8 @@ public class ReactNativeNotificationHubModuleTest {
         when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn(KEY_REGISTRATION_CONNECTIONSTRING);
         when(mConfig.getString(KEY_REGISTRATION_HUBNAME)).thenReturn(KEY_REGISTRATION_HUBNAME);
         when(mConfig.getString(KEY_REGISTRATION_SENDERID)).thenReturn(KEY_REGISTRATION_SENDERID);
-        when(mConfig.hasKey("channelShowBadge")).thenReturn(true);
-        when(mConfig.getBoolean("channelShowBadge")).thenReturn(channelShowBadge);
+        when(mConfig.hasKey(KEY_REGISTRATION_CHANNELSHOWBADGE)).thenReturn(true);
+        when(mConfig.getBoolean(KEY_REGISTRATION_CHANNELSHOWBADGE)).thenReturn(channelShowBadge);
 
         mHubModule.register(mConfig, mPromise);
 
@@ -227,8 +227,8 @@ public class ReactNativeNotificationHubModuleTest {
         when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn(KEY_REGISTRATION_CONNECTIONSTRING);
         when(mConfig.getString(KEY_REGISTRATION_HUBNAME)).thenReturn(KEY_REGISTRATION_HUBNAME);
         when(mConfig.getString(KEY_REGISTRATION_SENDERID)).thenReturn(KEY_REGISTRATION_SENDERID);
-        when(mConfig.hasKey("channelEnableLights")).thenReturn(true);
-        when(mConfig.getBoolean("channelEnableLights")).thenReturn(channelEnableLights);
+        when(mConfig.hasKey(KEY_REGISTRATION_CHANNELENABLELIGHTS)).thenReturn(true);
+        when(mConfig.getBoolean(KEY_REGISTRATION_CHANNELENABLELIGHTS)).thenReturn(channelEnableLights);
 
         mHubModule.register(mConfig, mPromise);
 
@@ -243,8 +243,8 @@ public class ReactNativeNotificationHubModuleTest {
         when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn(KEY_REGISTRATION_CONNECTIONSTRING);
         when(mConfig.getString(KEY_REGISTRATION_HUBNAME)).thenReturn(KEY_REGISTRATION_HUBNAME);
         when(mConfig.getString(KEY_REGISTRATION_SENDERID)).thenReturn(KEY_REGISTRATION_SENDERID);
-        when(mConfig.hasKey("channelEnableVibration")).thenReturn(true);
-        when(mConfig.getBoolean("channelEnableVibration")).thenReturn(channelEnableVibration);
+        when(mConfig.hasKey(KEY_REGISTRATION_CHANNELENABLEVIBRATION)).thenReturn(true);
+        when(mConfig.getBoolean(KEY_REGISTRATION_CHANNELENABLEVIBRATION)).thenReturn(channelEnableVibration);
 
         mHubModule.register(mConfig, mPromise);
 
@@ -290,9 +290,9 @@ public class ReactNativeNotificationHubModuleTest {
     public void testRegisterFailed() {
         final String[] tags = { "Tag" };
 
-        when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn(KEY_REGISTRATION_CONNECTIONSTRING);
-        when(mConfig.getString(KEY_REGISTRATION_HUBNAME)).thenReturn(KEY_REGISTRATION_HUBNAME);
-        when(mConfig.getString(KEY_REGISTRATION_SENDERID)).thenReturn(KEY_REGISTRATION_SENDERID);
+        when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn("Connection String");
+        when(mConfig.getString(KEY_REGISTRATION_HUBNAME)).thenReturn("Hub Name");
+        when(mConfig.getString(KEY_REGISTRATION_SENDERID)).thenReturn("Sender ID");
         when(mConfig.hasKey(KEY_REGISTRATION_TAGS)).thenReturn(true);
         when(mConfig.isNull(KEY_REGISTRATION_TAGS)).thenReturn(false);
         when(mConfig.getArray(KEY_REGISTRATION_TAGS)).thenReturn(mTags);
@@ -311,8 +311,8 @@ public class ReactNativeNotificationHubModuleTest {
 
     @Test
     public void testUnregisterSuccessfully() throws Exception {
-        when(mNotificationHubUtil.getConnectionString(any(ReactContext.class))).thenReturn(KEY_REGISTRATION_CONNECTIONSTRING);
-        when(mNotificationHubUtil.getHubName(any(ReactContext.class))).thenReturn(KEY_REGISTRATION_HUBNAME);
+        when(mNotificationHubUtil.getConnectionString(any(ReactContext.class))).thenReturn("Connection String");
+        when(mNotificationHubUtil.getHubName(any(ReactContext.class))).thenReturn("Hub Name");
         when(mNotificationHubUtil.getRegistrationID(any(ReactContext.class))).thenReturn("registrationId");
         when(ReactNativeUtil.createNotificationHub(
                 anyString(), anyString(), any(ReactContext.class))).thenReturn(mNotificationHub);
@@ -327,8 +327,8 @@ public class ReactNativeNotificationHubModuleTest {
 
     @Test
     public void testUnregisterNoRegistration() throws Exception {
-        when(mNotificationHubUtil.getConnectionString(any(ReactContext.class))).thenReturn(KEY_REGISTRATION_CONNECTIONSTRING);
-        when(mNotificationHubUtil.getHubName(any(ReactContext.class))).thenReturn(KEY_REGISTRATION_HUBNAME);
+        when(mNotificationHubUtil.getConnectionString(any(ReactContext.class))).thenReturn("Connection String");
+        when(mNotificationHubUtil.getHubName(any(ReactContext.class))).thenReturn("Hub Name");
         when(mNotificationHubUtil.getRegistrationID(any(ReactContext.class))).thenReturn(null);
         when(ReactNativeUtil.createNotificationHub(
                 anyString(), anyString(), any(ReactContext.class))).thenReturn(mNotificationHub);
@@ -344,8 +344,8 @@ public class ReactNativeNotificationHubModuleTest {
     public void testUnregisterThrowException() throws Exception {
         final Exception unhandledException = new Exception("Unhandled exception");
 
-        when(mNotificationHubUtil.getConnectionString(any(ReactContext.class))).thenReturn(KEY_REGISTRATION_CONNECTIONSTRING);
-        when(mNotificationHubUtil.getHubName(any(ReactContext.class))).thenReturn(KEY_REGISTRATION_HUBNAME);
+        when(mNotificationHubUtil.getConnectionString(any(ReactContext.class))).thenReturn("Connection String");
+        when(mNotificationHubUtil.getHubName(any(ReactContext.class))).thenReturn("Hub Name");
         when(mNotificationHubUtil.getRegistrationID(any(ReactContext.class))).thenReturn("registrationId");
         when(ReactNativeUtil.createNotificationHub(
                 anyString(), anyString(), any(ReactContext.class))).thenReturn(mNotificationHub);

--- a/sample/android/app/src/test/java/com/reactnativeazurenotificationhubsample/ReactNativeNotificationHubModuleTest.java
+++ b/sample/android/app/src/test/java/com/reactnativeazurenotificationhubsample/ReactNativeNotificationHubModuleTest.java
@@ -378,17 +378,16 @@ public class ReactNativeNotificationHubModuleTest {
         Bundle bundle = PowerMockito.mock(Bundle.class);
         when(mReactApplicationContext.getCurrentActivity()).thenReturn(activity);
         when(activity.getIntent()).thenReturn(intent);
-        when(intent.hasExtra(KEY_NOTIFICATION_PAYLOAD_TYPE)).thenReturn(true);
         when(ReactNativeUtil.getBundleFromIntent(intent)).thenReturn(bundle);
 
         mHubModule.onHostResume();
 
         verify(mNotificationHubUtil, times(1)).setAppIsForeground(true);
-        verify(intent, times(1)).hasExtra(KEY_NOTIFICATION_PAYLOAD_TYPE);
-        verify(intent, times(1)).removeExtra(KEY_NOTIFICATION_PAYLOAD_TYPE);
         verify(bundle, times(1)).putBoolean(KEY_REMOTE_NOTIFICATION_FOREGROUND, false);
         verify(bundle, times(1)).putBoolean(KEY_REMOTE_NOTIFICATION_USER_INTERACTION, true);
         verify(bundle, times(1)).putBoolean(KEY_REMOTE_NOTIFICATION_COLDSTART, true);
+        PowerMockito.verifyStatic(ReactNativeUtil.class);
+        ReactNativeUtil.removeNotificationFromIntent(intent);
         PowerMockito.verifyStatic(ReactNativeNotificationsHandler.class);
         ReactNativeNotificationsHandler.sendBroadcast(eq(mReactApplicationContext), eq(bundle), anyLong());
     }
@@ -400,17 +399,16 @@ public class ReactNativeNotificationHubModuleTest {
         Bundle bundle = PowerMockito.mock(Bundle.class);
         when(mReactApplicationContext.getCurrentActivity()).thenReturn(activity);
         when(activity.getIntent()).thenReturn(intent);
-        when(intent.hasExtra(KEY_NOTIFICATION_PAYLOAD_TYPE)).thenReturn(false);
         when(ReactNativeUtil.getBundleFromIntent(intent)).thenReturn(bundle);
 
         mHubModule.onHostResume();
 
         verify(mNotificationHubUtil, times(1)).setAppIsForeground(true);
-        verify(intent, times(1)).hasExtra(KEY_NOTIFICATION_PAYLOAD_TYPE);
-        verify(intent, times(0)).removeExtra(KEY_NOTIFICATION_PAYLOAD_TYPE);
         verify(bundle, times(1)).putBoolean(KEY_REMOTE_NOTIFICATION_FOREGROUND, false);
         verify(bundle, times(1)).putBoolean(KEY_REMOTE_NOTIFICATION_USER_INTERACTION, true);
         verify(bundle, times(1)).putBoolean(KEY_REMOTE_NOTIFICATION_COLDSTART, true);
+        PowerMockito.verifyStatic(ReactNativeUtil.class);
+        ReactNativeUtil.removeNotificationFromIntent(intent);
         PowerMockito.verifyStatic(ReactNativeNotificationsHandler.class);
         ReactNativeNotificationsHandler.sendBroadcast(eq(mReactApplicationContext), eq(bundle), anyLong());
     }

--- a/sample/android/app/src/test/java/com/reactnativeazurenotificationhubsample/ReactNativeNotificationHubModuleTest.java
+++ b/sample/android/app/src/test/java/com/reactnativeazurenotificationhubsample/ReactNativeNotificationHubModuleTest.java
@@ -138,7 +138,7 @@ public class ReactNativeNotificationHubModuleTest {
 
     @Test
     public void testRegisterMissingConnectionString() {
-        when(mConfig.getString("connectionString")).thenReturn(null);
+        when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn(null);
 
         mHubModule.register(mConfig, mPromise);
 
@@ -149,8 +149,8 @@ public class ReactNativeNotificationHubModuleTest {
 
     @Test
     public void testRegisterMissingHubName() {
-        when(mConfig.getString("connectionString")).thenReturn("connectionString");
-        when(mConfig.getString("hubName")).thenReturn(null);
+        when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn(KEY_REGISTRATION_CONNECTIONSTRING);
+        when(mConfig.getString(KEY_REGISTRATION_HUBNAME)).thenReturn(null);
 
         mHubModule.register(mConfig, mPromise);
 
@@ -161,9 +161,9 @@ public class ReactNativeNotificationHubModuleTest {
 
     @Test
     public void testRegisterMissingSenderID() {
-        when(mConfig.getString("connectionString")).thenReturn("connectionString");
-        when(mConfig.getString("hubName")).thenReturn("hubName");
-        when(mConfig.getString("senderID")).thenReturn(null);
+        when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn(KEY_REGISTRATION_CONNECTIONSTRING);
+        when(mConfig.getString(KEY_REGISTRATION_HUBNAME)).thenReturn(KEY_REGISTRATION_HUBNAME);
+        when(mConfig.getString(KEY_REGISTRATION_SENDERID)).thenReturn(null);
 
         mHubModule.register(mConfig, mPromise);
 
@@ -176,9 +176,9 @@ public class ReactNativeNotificationHubModuleTest {
     public void testRegisterHasChannelName() {
         final String channelName = "Channel Name";
 
-        when(mConfig.getString("connectionString")).thenReturn("connectionString");
-        when(mConfig.getString("hubName")).thenReturn("hubName");
-        when(mConfig.getString("senderID")).thenReturn("senderID");
+        when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn(KEY_REGISTRATION_CONNECTIONSTRING);
+        when(mConfig.getString(KEY_REGISTRATION_HUBNAME)).thenReturn(KEY_REGISTRATION_HUBNAME);
+        when(mConfig.getString(KEY_REGISTRATION_SENDERID)).thenReturn(KEY_REGISTRATION_SENDERID);
         when(mConfig.hasKey(KEY_REGISTRATION_CHANNELNAME)).thenReturn(true);
         when(mConfig.getString(KEY_REGISTRATION_CHANNELNAME)).thenReturn(channelName);
 
@@ -192,9 +192,9 @@ public class ReactNativeNotificationHubModuleTest {
     public void testRegisterHasChannelImportance() {
         final int channelImportance = 1;
 
-        when(mConfig.getString("connectionString")).thenReturn("connectionString");
-        when(mConfig.getString("hubName")).thenReturn("hubName");
-        when(mConfig.getString("senderID")).thenReturn("senderID");
+        when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn(KEY_REGISTRATION_CONNECTIONSTRING);
+        when(mConfig.getString(KEY_REGISTRATION_HUBNAME)).thenReturn(KEY_REGISTRATION_HUBNAME);
+        when(mConfig.getString(KEY_REGISTRATION_SENDERID)).thenReturn(KEY_REGISTRATION_SENDERID);
         when(mConfig.hasKey("channelImportance")).thenReturn(true);
         when(mConfig.getInt("channelImportance")).thenReturn(channelImportance);
 
@@ -208,9 +208,9 @@ public class ReactNativeNotificationHubModuleTest {
     public void testRegisterHasChannelShowBadge() {
         final boolean channelShowBadge = true;
 
-        when(mConfig.getString("connectionString")).thenReturn("connectionString");
-        when(mConfig.getString("hubName")).thenReturn("hubName");
-        when(mConfig.getString("senderID")).thenReturn("senderID");
+        when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn(KEY_REGISTRATION_CONNECTIONSTRING);
+        when(mConfig.getString(KEY_REGISTRATION_HUBNAME)).thenReturn(KEY_REGISTRATION_HUBNAME);
+        when(mConfig.getString(KEY_REGISTRATION_SENDERID)).thenReturn(KEY_REGISTRATION_SENDERID);
         when(mConfig.hasKey("channelShowBadge")).thenReturn(true);
         when(mConfig.getBoolean("channelShowBadge")).thenReturn(channelShowBadge);
 
@@ -224,9 +224,9 @@ public class ReactNativeNotificationHubModuleTest {
     public void testRegisterHasChannelEnableLights() {
         final boolean channelEnableLights = true;
 
-        when(mConfig.getString("connectionString")).thenReturn("connectionString");
-        when(mConfig.getString("hubName")).thenReturn("hubName");
-        when(mConfig.getString("senderID")).thenReturn("senderID");
+        when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn(KEY_REGISTRATION_CONNECTIONSTRING);
+        when(mConfig.getString(KEY_REGISTRATION_HUBNAME)).thenReturn(KEY_REGISTRATION_HUBNAME);
+        when(mConfig.getString(KEY_REGISTRATION_SENDERID)).thenReturn(KEY_REGISTRATION_SENDERID);
         when(mConfig.hasKey("channelEnableLights")).thenReturn(true);
         when(mConfig.getBoolean("channelEnableLights")).thenReturn(channelEnableLights);
 
@@ -240,9 +240,9 @@ public class ReactNativeNotificationHubModuleTest {
     public void testRegisterHasChannelEnableVibration() {
         final boolean channelEnableVibration = true;
 
-        when(mConfig.getString("connectionString")).thenReturn("connectionString");
-        when(mConfig.getString("hubName")).thenReturn("hubName");
-        when(mConfig.getString("senderID")).thenReturn("senderID");
+        when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn(KEY_REGISTRATION_CONNECTIONSTRING);
+        when(mConfig.getString(KEY_REGISTRATION_HUBNAME)).thenReturn(KEY_REGISTRATION_HUBNAME);
+        when(mConfig.getString(KEY_REGISTRATION_SENDERID)).thenReturn(KEY_REGISTRATION_SENDERID);
         when(mConfig.hasKey("channelEnableVibration")).thenReturn(true);
         when(mConfig.getBoolean("channelEnableVibration")).thenReturn(channelEnableVibration);
 
@@ -254,17 +254,17 @@ public class ReactNativeNotificationHubModuleTest {
 
     @Test
     public void testRegisterSuccessfully() {
-        final String connectionString = "connectionString";
-        final String hubName = "hubName";
-        final String senderID = "senderID";
-        final String[] tags = {"tags"};
+        final String connectionString = "Connection String";
+        final String hubName = "Hub Name";
+        final String senderID = "Sender ID";
+        final String[] tags = { "Tag" };
 
-        when(mConfig.getString("connectionString")).thenReturn(connectionString);
-        when(mConfig.getString("hubName")).thenReturn(hubName);
-        when(mConfig.getString("senderID")).thenReturn(senderID);
-        when(mConfig.hasKey("tags")).thenReturn(true);
-        when(mConfig.isNull("tags")).thenReturn(false);
-        when(mConfig.getArray("tags")).thenReturn(mTags);
+        when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn(connectionString);
+        when(mConfig.getString(KEY_REGISTRATION_HUBNAME)).thenReturn(hubName);
+        when(mConfig.getString(KEY_REGISTRATION_SENDERID)).thenReturn(senderID);
+        when(mConfig.hasKey(KEY_REGISTRATION_TAGS)).thenReturn(true);
+        when(mConfig.isNull(KEY_REGISTRATION_TAGS)).thenReturn(false);
+        when(mConfig.getArray(KEY_REGISTRATION_TAGS)).thenReturn(mTags);
         when(mTags.size()).thenReturn(1);
         when(mTags.getString(0)).thenReturn(tags[0]);
         when(mGoogleApiAvailability.isGooglePlayServicesAvailable(any())).thenReturn(
@@ -288,14 +288,14 @@ public class ReactNativeNotificationHubModuleTest {
 
     @Test
     public void testRegisterFailed() {
-        final String[] tags = {"tags"};
+        final String[] tags = { "Tag" };
 
-        when(mConfig.getString("connectionString")).thenReturn("connectionString");
-        when(mConfig.getString("hubName")).thenReturn("hubName");
-        when(mConfig.getString("senderID")).thenReturn("senderID");
-        when(mConfig.hasKey("tags")).thenReturn(true);
-        when(mConfig.isNull("tags")).thenReturn(false);
-        when(mConfig.getArray("tags")).thenReturn(mTags);
+        when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn(KEY_REGISTRATION_CONNECTIONSTRING);
+        when(mConfig.getString(KEY_REGISTRATION_HUBNAME)).thenReturn(KEY_REGISTRATION_HUBNAME);
+        when(mConfig.getString(KEY_REGISTRATION_SENDERID)).thenReturn(KEY_REGISTRATION_SENDERID);
+        when(mConfig.hasKey(KEY_REGISTRATION_TAGS)).thenReturn(true);
+        when(mConfig.isNull(KEY_REGISTRATION_TAGS)).thenReturn(false);
+        when(mConfig.getArray(KEY_REGISTRATION_TAGS)).thenReturn(mTags);
         when(mTags.size()).thenReturn(1);
         when(mTags.getString(0)).thenReturn(tags[0]);
         when(mGoogleApiAvailability.isGooglePlayServicesAvailable(any())).thenReturn(
@@ -311,8 +311,8 @@ public class ReactNativeNotificationHubModuleTest {
 
     @Test
     public void testUnregisterSuccessfully() throws Exception {
-        when(mNotificationHubUtil.getConnectionString(any(ReactContext.class))).thenReturn("connectionString");
-        when(mNotificationHubUtil.getHubName(any(ReactContext.class))).thenReturn("hubName");
+        when(mNotificationHubUtil.getConnectionString(any(ReactContext.class))).thenReturn(KEY_REGISTRATION_CONNECTIONSTRING);
+        when(mNotificationHubUtil.getHubName(any(ReactContext.class))).thenReturn(KEY_REGISTRATION_HUBNAME);
         when(mNotificationHubUtil.getRegistrationID(any(ReactContext.class))).thenReturn("registrationId");
         when(ReactNativeUtil.createNotificationHub(
                 anyString(), anyString(), any(ReactContext.class))).thenReturn(mNotificationHub);
@@ -327,8 +327,8 @@ public class ReactNativeNotificationHubModuleTest {
 
     @Test
     public void testUnregisterNoRegistration() throws Exception {
-        when(mNotificationHubUtil.getConnectionString(any(ReactContext.class))).thenReturn("connectionString");
-        when(mNotificationHubUtil.getHubName(any(ReactContext.class))).thenReturn("hubName");
+        when(mNotificationHubUtil.getConnectionString(any(ReactContext.class))).thenReturn(KEY_REGISTRATION_CONNECTIONSTRING);
+        when(mNotificationHubUtil.getHubName(any(ReactContext.class))).thenReturn(KEY_REGISTRATION_HUBNAME);
         when(mNotificationHubUtil.getRegistrationID(any(ReactContext.class))).thenReturn(null);
         when(ReactNativeUtil.createNotificationHub(
                 anyString(), anyString(), any(ReactContext.class))).thenReturn(mNotificationHub);
@@ -344,8 +344,8 @@ public class ReactNativeNotificationHubModuleTest {
     public void testUnregisterThrowException() throws Exception {
         final Exception unhandledException = new Exception("Unhandled exception");
 
-        when(mNotificationHubUtil.getConnectionString(any(ReactContext.class))).thenReturn("connectionString");
-        when(mNotificationHubUtil.getHubName(any(ReactContext.class))).thenReturn("hubName");
+        when(mNotificationHubUtil.getConnectionString(any(ReactContext.class))).thenReturn(KEY_REGISTRATION_CONNECTIONSTRING);
+        when(mNotificationHubUtil.getHubName(any(ReactContext.class))).thenReturn(KEY_REGISTRATION_HUBNAME);
         when(mNotificationHubUtil.getRegistrationID(any(ReactContext.class))).thenReturn("registrationId");
         when(ReactNativeUtil.createNotificationHub(
                 anyString(), anyString(), any(ReactContext.class))).thenReturn(mNotificationHub);

--- a/sample/android/app/src/test/java/com/reactnativeazurenotificationhubsample/ReactNativeNotificationHubUtilTest.java
+++ b/sample/android/app/src/test/java/com/reactnativeazurenotificationhubsample/ReactNativeNotificationHubUtilTest.java
@@ -195,6 +195,32 @@ public class ReactNativeNotificationHubUtilTest {
     }
 
     @Test
+    public void testGetChannelName() {
+        mHubUtil.getChannelName(mReactApplicationContext);
+
+        verify(mSharedPreferences, times(1)).getString(
+                KEY_FOR_PREFS_CHANNELNAME, null);
+    }
+
+    @Test
+    public void testSetChannelName() {
+        final String channelName = "Channel Name";
+
+        mHubUtil.setChannelName(mReactApplicationContext, channelName);
+
+        verify(mEditor, times(1)).putString(
+                KEY_FOR_PREFS_CHANNELNAME, channelName);
+        verify(mEditor, times(1)).apply();
+    }
+
+    @Test
+    public void testHasChannelName() {
+        mHubUtil.hasChannelName(mReactApplicationContext);
+
+        verify(mSharedPreferences, times(1)).contains(KEY_FOR_PREFS_CHANNELNAME);
+    }
+
+    @Test
     public void testGetChannelImportance() {
         mHubUtil.getChannelImportance(mReactApplicationContext);
 

--- a/sample/android/app/src/test/java/com/reactnativeazurenotificationhubsample/ReactNativeNotificationsHandlerTest.java
+++ b/sample/android/app/src/test/java/com/reactnativeazurenotificationhubsample/ReactNativeNotificationsHandlerTest.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
+import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.net.Uri;
@@ -83,6 +84,7 @@ public class ReactNativeNotificationsHandlerTest {
     Bundle mBundle;
 
     private Class mIntentClass;
+    private ArgumentCaptor<Runnable> mWorkerTask;
 
     @Before
     public void setUp() throws Exception {
@@ -104,6 +106,9 @@ public class ReactNativeNotificationsHandlerTest {
 
         mIntentClass = Class.forName("com.reactnativeazurenotificationhubsample.MainActivity");
         when(ReactNativeUtil.getMainActivityClass(mReactApplicationContext)).thenReturn(mIntentClass);
+        mWorkerTask = ArgumentCaptor.forClass(Runnable.class);
+        PowerMockito.doNothing().when(
+                ReactNativeUtil.class, "runInWorkerThread", mWorkerTask.capture());
         mNotificationBuilder = PowerMockito.mock(NotificationCompat.Builder.class);
         when(ReactNativeUtil.initNotificationCompatBuilder(
                 any(), any(), any(), any(), anyInt(), anyInt(), anyBoolean())).thenReturn(mNotificationBuilder);
@@ -116,12 +121,9 @@ public class ReactNativeNotificationsHandlerTest {
         final int delay = 1000;
 
         Intent intent = PowerMockito.mock(Intent.class);
-        ArgumentCaptor<Runnable> workerTask = ArgumentCaptor.forClass(Runnable.class);
-        PowerMockito.doNothing().when(
-                ReactNativeUtil.class, "runInWorkerThread", workerTask.capture());
 
         sendBroadcast(mReactApplicationContext, intent, delay);
-        workerTask.getValue().run();
+        mWorkerTask.getValue().run();
 
         PowerMockito.verifyStatic(ReactNativeUtil.class);
         ReactNativeUtil.runInWorkerThread(any(Runnable.class));
@@ -135,12 +137,8 @@ public class ReactNativeNotificationsHandlerTest {
         Intent intent = PowerMockito.mock(Intent.class);
         when(ReactNativeUtil.createBroadcastIntent(TAG, mBundle)).thenReturn(intent);
 
-        ArgumentCaptor<Runnable> workerTask = ArgumentCaptor.forClass(Runnable.class);
-        PowerMockito.doNothing().when(
-                ReactNativeUtil.class, "runInWorkerThread", workerTask.capture());
-
         sendBroadcast(mReactApplicationContext, mBundle, delay);
-        workerTask.getValue().run();
+        mWorkerTask.getValue().run();
 
         PowerMockito.verifyStatic(ReactNativeUtil.class);
         ReactNativeUtil.runInWorkerThread(any(Runnable.class));
@@ -156,6 +154,7 @@ public class ReactNativeNotificationsHandlerTest {
         Bundle bundle = PowerMockito.mock(Bundle.class);
 
         sendNotification(mReactApplicationContext, bundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
 
         PowerMockito.verifyStatic(Log.class);
         Log.e(TAG, ERROR_NO_ACTIVITY_CLASS);
@@ -166,6 +165,7 @@ public class ReactNativeNotificationsHandlerTest {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_BODY)).thenReturn(null);
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
         PowerMockito.verifyStatic(Log.class, times(0));
         Log.e(TAG, ERROR_NO_MESSAGE);
 
@@ -173,6 +173,7 @@ public class ReactNativeNotificationsHandlerTest {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(null);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_BODY)).thenReturn(NOTIFICATION_MESSAGE);
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
         PowerMockito.verifyStatic(Log.class, times(0));
         Log.e(TAG, ERROR_NO_MESSAGE);
 
@@ -180,6 +181,7 @@ public class ReactNativeNotificationsHandlerTest {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(null);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_BODY)).thenReturn(null);
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
         PowerMockito.verifyStatic(Log.class);
         Log.e(TAG, ERROR_NO_MESSAGE);
     }
@@ -197,6 +199,7 @@ public class ReactNativeNotificationsHandlerTest {
         when(applicationLabel.toString()).thenReturn(NOTIFICATION_TITLE);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
 
         PowerMockito.verifyStatic(ReactNativeUtil.class);
         ReactNativeUtil.initNotificationCompatBuilder(
@@ -209,6 +212,7 @@ public class ReactNativeNotificationsHandlerTest {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
 
         PowerMockito.verifyStatic(ReactNativeUtil.class);
         ReactNativeUtil.initNotificationCompatBuilder(
@@ -226,6 +230,7 @@ public class ReactNativeNotificationsHandlerTest {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
 
         PowerMockito.verifyStatic(ReactNativeUtil.class);
         ReactNativeUtil.getNotificationCompatPriority(null);
@@ -238,6 +243,7 @@ public class ReactNativeNotificationsHandlerTest {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_PRIORITY)).thenReturn(NOTIFICATION_PRIORITY);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
 
         PowerMockito.verifyStatic(ReactNativeUtil.class);
         ReactNativeUtil.getNotificationCompatPriority(NOTIFICATION_PRIORITY);
@@ -252,6 +258,7 @@ public class ReactNativeNotificationsHandlerTest {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_GROUP)).thenReturn(group);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
 
         verify(mNotificationBuilder, times(1)).setGroup(group);
     }
@@ -262,6 +269,7 @@ public class ReactNativeNotificationsHandlerTest {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
 
         verify(mNotificationBuilder, times(1)).setContentText(NOTIFICATION_MESSAGE);
     }
@@ -275,6 +283,7 @@ public class ReactNativeNotificationsHandlerTest {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_SUB_TEXT)).thenReturn(subText);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
 
         verify(mNotificationBuilder, times(1)).setSubText(subText);
     }
@@ -288,6 +297,7 @@ public class ReactNativeNotificationsHandlerTest {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_NUMBER)).thenReturn(strNumber);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
 
         verify(mNotificationBuilder, times(1)).setNumber(Integer.parseInt(strNumber));
     }
@@ -298,6 +308,7 @@ public class ReactNativeNotificationsHandlerTest {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
 
         PowerMockito.verifyStatic(ReactNativeUtil.class);
         ReactNativeUtil.getSmallIcon(any(), any(), any());
@@ -310,6 +321,7 @@ public class ReactNativeNotificationsHandlerTest {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
 
         PowerMockito.verifyStatic(ReactNativeUtil.class);
         ReactNativeUtil.getLargeIcon(any(), eq(null), any(), any());
@@ -327,10 +339,42 @@ public class ReactNativeNotificationsHandlerTest {
         when(ReactNativeUtil.getLargeIcon(any(), any(), any(), any())).thenReturn(largeIconResID);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
 
         PowerMockito.verifyStatic(ReactNativeUtil.class);
         ReactNativeUtil.getLargeIcon(any(), eq(largeIcon), any(), any());
         verify(mNotificationBuilder, times(1)).setLargeIcon(any());
+    }
+
+    @Test
+    public void testSendNotificationHasAvatarUrl() {
+        final String url = "http://avatar.com/1.png";
+
+        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
+        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
+        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_AVATAR_URL)).thenReturn(url);
+        Bitmap bitmap = PowerMockito.mock(Bitmap.class);
+        when(ReactNativeUtil.fetchImage(url)).thenReturn(bitmap);
+
+        sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
+
+        verify(mNotificationBuilder, times(1)).setLargeIcon(bitmap);
+    }
+
+    @Test
+    public void testSendNotificationHasAvatarUrlFetchFailed() {
+        final String url = "http://avatar.com/1.png";
+
+        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
+        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
+        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_AVATAR_URL)).thenReturn(url);
+        when(ReactNativeUtil.fetchImage(url)).thenReturn(null);
+
+        sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
+
+        verify(mNotificationBuilder, times(0)).setLargeIcon(any());
     }
 
     @Test
@@ -342,6 +386,7 @@ public class ReactNativeNotificationsHandlerTest {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_BIG_TEXT)).thenReturn(bigText);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
 
         verify(mBundle, times(1)).getString(KEY_REMOTE_NOTIFICATION_BIG_TEXT);
         PowerMockito.verifyStatic(ReactNativeUtil.class);
@@ -355,6 +400,7 @@ public class ReactNativeNotificationsHandlerTest {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_BIG_TEXT)).thenReturn(null);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
 
         verify(mBundle, times(1)).getString(KEY_REMOTE_NOTIFICATION_BIG_TEXT);
         PowerMockito.verifyStatic(ReactNativeUtil.class);
@@ -368,6 +414,7 @@ public class ReactNativeNotificationsHandlerTest {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_BIG_TEXT)).thenReturn(null);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
 
         verify(mBundle, times(1)).getString(KEY_REMOTE_NOTIFICATION_BIG_TEXT);
         PowerMockito.verifyStatic(ReactNativeUtil.class);
@@ -380,6 +427,7 @@ public class ReactNativeNotificationsHandlerTest {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
 
         PowerMockito.verifyStatic(ReactNativeUtil.class);
         ReactNativeUtil.createNotificationIntent(any(), any(), any());
@@ -396,6 +444,7 @@ public class ReactNativeNotificationsHandlerTest {
         when(ReactNativeUtil.getSoundUri(any(), any())).thenReturn(soundUri);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
 
         PowerMockito.verifyStatic(ReactNativeUtil.class);
         ReactNativeUtil.getSoundUri(any(), any());
@@ -410,6 +459,7 @@ public class ReactNativeNotificationsHandlerTest {
         when(mBundle.getBoolean(KEY_REMOTE_NOTIFICATION_PLAY_SOUND)).thenReturn(false);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
 
         PowerMockito.verifyStatic(ReactNativeUtil.class, times(0));
         ReactNativeUtil.getSoundUri(any(), any());
@@ -425,6 +475,7 @@ public class ReactNativeNotificationsHandlerTest {
         when(mBundle.getBoolean(KEY_REMOTE_NOTIFICATION_ONGOING)).thenReturn(ongoing);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
 
         verify(mNotificationBuilder, times(1)).setOngoing(ongoing);
     }
@@ -439,8 +490,8 @@ public class ReactNativeNotificationsHandlerTest {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_COLOR)).thenReturn(color);
 
         Whitebox.setInternalState(Build.VERSION.class, "SDK_INT", sdkVersion);
-
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
 
         verify(mNotificationBuilder, times(1)).setCategory(NotificationCompat.CATEGORY_CALL);
         verify(mNotificationBuilder, times(1)).setColor(Color.parseColor(color));
@@ -453,6 +504,7 @@ public class ReactNativeNotificationsHandlerTest {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
 
         verify(mNotificationBuilder, times(1)).setContentIntent(any());
     }
@@ -465,6 +517,7 @@ public class ReactNativeNotificationsHandlerTest {
         when(mBundle.getBoolean(KEY_REMOTE_NOTIFICATION_VIBRATE)).thenReturn(false);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
 
         verify(mNotificationBuilder, times(0)).setVibrate(any());
     }
@@ -477,6 +530,7 @@ public class ReactNativeNotificationsHandlerTest {
         when(mBundle.containsKey(KEY_REMOTE_NOTIFICATION_VIBRATE)).thenReturn(false);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
 
         verify(mNotificationBuilder, times(1)).setVibrate(any());
     }
@@ -488,6 +542,7 @@ public class ReactNativeNotificationsHandlerTest {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
 
         PowerMockito.verifyStatic(ReactNativeUtil.class);
         ReactNativeUtil.processNotificationActions(any(), any(), any(), anyInt());
@@ -503,6 +558,7 @@ public class ReactNativeNotificationsHandlerTest {
                 notificationManager);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
 
         PowerMockito.verifyStatic(ReactNativeUtil.class);
         ReactNativeUtil.processNotificationActions(any(), any(), any(), anyInt());
@@ -523,6 +579,7 @@ public class ReactNativeNotificationsHandlerTest {
                 notificationManager);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        mWorkerTask.getValue().run();
 
         PowerMockito.verifyStatic(ReactNativeUtil.class);
         ReactNativeUtil.processNotificationActions(any(), any(), any(), anyInt());

--- a/sample/android/app/src/test/java/com/reactnativeazurenotificationhubsample/ReactNativeNotificationsHandlerTest.java
+++ b/sample/android/app/src/test/java/com/reactnativeazurenotificationhubsample/ReactNativeNotificationsHandlerTest.java
@@ -59,8 +59,8 @@ import com.facebook.react.bridge.ReactApplicationContext;
 })
 public class ReactNativeNotificationsHandlerTest {
     private final static String CHANNEL_ID = "Channel ID";
-    private final static String NOTIFICATION_TITLE = "Notification Title";
     private final static String NOTIFICATION_ID = "Notification ID";
+    private final static String NOTIFICATION_TITLE = "Notification Title";
     private final static String NOTIFICATION_MESSAGE = "Notification Message";
     private final static String NOTIFICATION_PRIORITY = "normal";
 
@@ -163,26 +163,30 @@ public class ReactNativeNotificationsHandlerTest {
 
     @Test
     public void testSendNotificationNoMessage() {
+        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
+        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_BODY)).thenReturn(null);
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        PowerMockito.verifyStatic(Log.class, times(0));
+        Log.e(TAG, ERROR_NO_MESSAGE);
 
+        reset(mBundle);
+        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(null);
+        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_BODY)).thenReturn(NOTIFICATION_MESSAGE);
+        sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+        PowerMockito.verifyStatic(Log.class, times(0));
+        Log.e(TAG, ERROR_NO_MESSAGE);
+
+        reset(mBundle);
+        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(null);
+        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_BODY)).thenReturn(null);
+        sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
         PowerMockito.verifyStatic(Log.class);
         Log.e(TAG, ERROR_NO_MESSAGE);
     }
 
     @Test
-    public void testSendNotificationNoNotifID() {
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
-
-        sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
-
-        PowerMockito.verifyStatic(Log.class);
-        Log.e(TAG, ERROR_NO_NOTIF_ID);
-    }
-
-    @Test
     public void testSendNotificationNoTitle() {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ID)).thenReturn(NOTIFICATION_ID);
 
         ApplicationInfo appInfo = PowerMockito.mock(ApplicationInfo.class);
         PackageManager packageManager = PowerMockito.mock(PackageManager.class);
@@ -202,7 +206,6 @@ public class ReactNativeNotificationsHandlerTest {
     @Test
     public void testSendNotificationHasTitle() {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ID)).thenReturn(NOTIFICATION_ID);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
@@ -220,7 +223,6 @@ public class ReactNativeNotificationsHandlerTest {
     @Test
     public void testSendNotificationNoPriority() {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ID)).thenReturn(NOTIFICATION_ID);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
@@ -232,7 +234,6 @@ public class ReactNativeNotificationsHandlerTest {
     @Test
     public void testSendNotificationHasPriority() {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ID)).thenReturn(NOTIFICATION_ID);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_PRIORITY)).thenReturn(NOTIFICATION_PRIORITY);
 
@@ -247,7 +248,6 @@ public class ReactNativeNotificationsHandlerTest {
         final String group = "Notification Group";
 
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ID)).thenReturn(NOTIFICATION_ID);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_GROUP)).thenReturn(group);
 
@@ -259,7 +259,6 @@ public class ReactNativeNotificationsHandlerTest {
     @Test
     public void testSendNotificationSetContentText() {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ID)).thenReturn(NOTIFICATION_ID);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
@@ -272,7 +271,6 @@ public class ReactNativeNotificationsHandlerTest {
         final String subText = "Sub Text";
 
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ID)).thenReturn(NOTIFICATION_ID);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_SUB_TEXT)).thenReturn(subText);
 
@@ -286,7 +284,6 @@ public class ReactNativeNotificationsHandlerTest {
         final String strNumber = "1";
 
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ID)).thenReturn(NOTIFICATION_ID);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_NUMBER)).thenReturn(strNumber);
 
@@ -298,7 +295,6 @@ public class ReactNativeNotificationsHandlerTest {
     @Test
     public void testSendNotificationHasSmallIcon() {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ID)).thenReturn(NOTIFICATION_ID);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
@@ -311,7 +307,6 @@ public class ReactNativeNotificationsHandlerTest {
     @Test
     public void testSendNotificationNoLargeIcon() {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ID)).thenReturn(NOTIFICATION_ID);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
@@ -327,7 +322,6 @@ public class ReactNativeNotificationsHandlerTest {
         final int largeIconResID = 1;
 
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ID)).thenReturn(NOTIFICATION_ID);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_LARGE_ICON)).thenReturn(largeIcon);
         when(ReactNativeUtil.getLargeIcon(any(), any(), any(), any())).thenReturn(largeIconResID);
@@ -340,38 +334,49 @@ public class ReactNativeNotificationsHandlerTest {
     }
 
     @Test
-    public void testSendNotificationNoBigText() {
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ID)).thenReturn(NOTIFICATION_ID);
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
-
-        sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
-
-        verify(mBundle, times(1)).getString(KEY_REMOTE_NOTIFICATION_BIG_TEXT);
-        verify(mBundle, times(3)).getString(KEY_REMOTE_NOTIFICATION_MESSAGE);
-        verify(mNotificationBuilder, times(1)).setStyle(any());
-    }
-
-    @Test
     public void testSendNotificationHasBigText() {
         final String bigText = "Big Text";
 
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ID)).thenReturn(NOTIFICATION_ID);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_BIG_TEXT)).thenReturn(bigText);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
 
         verify(mBundle, times(1)).getString(KEY_REMOTE_NOTIFICATION_BIG_TEXT);
-        verify(mBundle, times(2)).getString(KEY_REMOTE_NOTIFICATION_MESSAGE);
-        verify(mNotificationBuilder, times(1)).setStyle(any());
+        PowerMockito.verifyStatic(ReactNativeUtil.class);
+        ReactNativeUtil.getBigTextStyle(bigText);
+    }
+
+    @Test
+    public void testSendNotificationNoBigTextMessage() {
+        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn("message");
+        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
+        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_BIG_TEXT)).thenReturn(null);
+
+        sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+
+        verify(mBundle, times(1)).getString(KEY_REMOTE_NOTIFICATION_BIG_TEXT);
+        PowerMockito.verifyStatic(ReactNativeUtil.class);
+        ReactNativeUtil.getBigTextStyle("message");
+    }
+
+    @Test
+    public void testSendNotificationNoBigTextBody() {
+        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_BODY)).thenReturn("body");
+        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
+        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_BIG_TEXT)).thenReturn(null);
+
+        sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
+
+        verify(mBundle, times(1)).getString(KEY_REMOTE_NOTIFICATION_BIG_TEXT);
+        PowerMockito.verifyStatic(ReactNativeUtil.class);
+        ReactNativeUtil.getBigTextStyle("body");
     }
 
     @Test
     public void testSendNotificationCreateNotificationIntent() {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ID)).thenReturn(NOTIFICATION_ID);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
@@ -385,7 +390,6 @@ public class ReactNativeNotificationsHandlerTest {
         final String playSound = "Play Sound";
 
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ID)).thenReturn(NOTIFICATION_ID);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
         when(mBundle.getBoolean(KEY_REMOTE_NOTIFICATION_PLAY_SOUND)).thenReturn(true);
         Uri soundUri = PowerMockito.mock(Uri.class);
@@ -401,7 +405,6 @@ public class ReactNativeNotificationsHandlerTest {
     @Test
     public void testSendNotificationDisableSound() {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ID)).thenReturn(NOTIFICATION_ID);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
         when(mBundle.containsKey(KEY_REMOTE_NOTIFICATION_PLAY_SOUND)).thenReturn(true);
         when(mBundle.getBoolean(KEY_REMOTE_NOTIFICATION_PLAY_SOUND)).thenReturn(false);
@@ -417,7 +420,6 @@ public class ReactNativeNotificationsHandlerTest {
         final boolean ongoing = true;
 
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ID)).thenReturn(NOTIFICATION_ID);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
         when(mBundle.containsKey(KEY_REMOTE_NOTIFICATION_ONGOING)).thenReturn(true);
         when(mBundle.getBoolean(KEY_REMOTE_NOTIFICATION_ONGOING)).thenReturn(ongoing);
@@ -433,7 +435,6 @@ public class ReactNativeNotificationsHandlerTest {
         final String color = "#FF00FF";
 
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ID)).thenReturn(NOTIFICATION_ID);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_COLOR)).thenReturn(color);
 
@@ -447,8 +448,8 @@ public class ReactNativeNotificationsHandlerTest {
 
     @Test
     public void testSendNotificationSetContentIntent() {
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ID)).thenReturn(NOTIFICATION_ID);
+        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
@@ -459,7 +460,6 @@ public class ReactNativeNotificationsHandlerTest {
     @Test
     public void testSendNotificationDisableVibration() {
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ID)).thenReturn(NOTIFICATION_ID);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
         when(mBundle.containsKey(KEY_REMOTE_NOTIFICATION_VIBRATE)).thenReturn(true);
         when(mBundle.getBoolean(KEY_REMOTE_NOTIFICATION_VIBRATE)).thenReturn(false);
@@ -471,8 +471,8 @@ public class ReactNativeNotificationsHandlerTest {
 
     @Test
     public void testSendNotificationHasVibration() {
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ID)).thenReturn(NOTIFICATION_ID);
+        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
         when(mBundle.containsKey(KEY_REMOTE_NOTIFICATION_VIBRATE)).thenReturn(false);
 
@@ -483,8 +483,8 @@ public class ReactNativeNotificationsHandlerTest {
 
     @Test
     public void testSendNotificationProcessActions() {
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ID)).thenReturn(NOTIFICATION_ID);
+        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
 
         sendNotification(mReactApplicationContext, mBundle, CHANNEL_ID);
@@ -495,8 +495,8 @@ public class ReactNativeNotificationsHandlerTest {
 
     @Test
     public void testSendNotificationNotifyNoTag() {
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ID)).thenReturn(NOTIFICATION_ID);
+        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
         NotificationManager notificationManager = PowerMockito.mock(NotificationManager.class);
         when(mReactApplicationContext.getSystemService(Context.NOTIFICATION_SERVICE)).thenReturn(
@@ -513,8 +513,8 @@ public class ReactNativeNotificationsHandlerTest {
     public void testSendNotificationNotifyHasTag() {
         final String tags = "[ Tag0, Tag1, Tag2 ]";
 
-        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ID)).thenReturn(NOTIFICATION_ID);
+        when(mBundle.getString(KEY_REMOTE_NOTIFICATION_MESSAGE)).thenReturn(NOTIFICATION_MESSAGE);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TITLE)).thenReturn(NOTIFICATION_TITLE);
         when(mBundle.containsKey(KEY_REMOTE_NOTIFICATION_TAG)).thenReturn(true);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_TAG)).thenReturn(tags);

--- a/sample/android/app/src/test/java/com/reactnativeazurenotificationhubsample/ReactNativeUtilTest.java
+++ b/sample/android/app/src/test/java/com/reactnativeazurenotificationhubsample/ReactNativeUtilTest.java
@@ -511,7 +511,7 @@ public class ReactNativeUtilTest {
         PowerMockito.verifyStatic(IntentFactory.class);
         IntentFactory.createIntent(mReactApplicationContext, null);
         verify(intent, times(1)).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-        verify(intent, times(1)).putExtra(KEY_INTENT_NOTIFICATION, mBundle);
+        verify(intent, times(1)).putExtra(KEY_NOTIFICATION_PAYLOAD_TYPE, mBundle);
         verify(mBundle, times(1)).putBoolean(
                 KEY_REMOTE_NOTIFICATION_FOREGROUND, true);
         verify(mBundle, times(1)).putBoolean(
@@ -596,5 +596,26 @@ public class ReactNativeUtilTest {
                 KEY_REMOTE_NOTIFICATION_ACTION, "Action");
         verify(notificationBuilder, times(2)).addAction(
                 eq(0), eq("Action"), any());
+    }
+
+    @Test
+    public void testGetBundleFromIntent() {
+        Intent intent = PowerMockito.mock(Intent.class);
+        when(intent.hasExtra(KEY_NOTIFICATION_PAYLOAD_TYPE)).thenReturn(true);
+        getBundleFromIntent(intent);
+        verify(intent, times(1)).getBundleExtra(KEY_NOTIFICATION_PAYLOAD_TYPE);
+
+        reset(intent);
+        when(intent.hasExtra(KEY_NOTIFICATION_PAYLOAD_TYPE)).thenReturn(false);
+        when(intent.hasExtra(KEY_REMOTE_NOTIFICATION_ID)).thenReturn(true);
+        getBundleFromIntent(intent);
+        verify(intent, times(1)).getExtras();
+
+        reset(intent);
+        when(intent.hasExtra(KEY_NOTIFICATION_PAYLOAD_TYPE)).thenReturn(false);
+        when(intent.hasExtra(KEY_REMOTE_NOTIFICATION_ID)).thenReturn(false);
+        getBundleFromIntent(intent);
+        verify(intent, times(0)).getBundleExtra(KEY_NOTIFICATION_PAYLOAD_TYPE);
+        verify(intent, times(0)).getExtras();
     }
 }

--- a/sample/android/app/src/test/java/com/reactnativeazurenotificationhubsample/ReactNativeUtilTest.java
+++ b/sample/android/app/src/test/java/com/reactnativeazurenotificationhubsample/ReactNativeUtilTest.java
@@ -21,6 +21,9 @@ import org.junit.Test;
 
 import static com.azure.reactnative.notificationhub.ReactNativeNotificationHubUtil.*;
 import static com.azure.reactnative.notificationhub.ReactNativeConstants.*;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyFloat;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.reset;
@@ -37,10 +40,16 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.azure.reactnative.notificationhub.ReactNativeUtil;
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
+
+import static com.azure.reactnative.notificationhub.ReactNativeUtil.*;
 
 /**
  * Unit tests for ReactNativeUtil.
@@ -52,6 +61,7 @@ import java.util.HashSet;
         Uri.class,
         IntentFactory.class,
         PendingIntent.class,
+        Arguments.class,
         Log.class
 })
 public class ReactNativeUtilTest {
@@ -72,38 +82,182 @@ public class ReactNativeUtilTest {
         PowerMockito.mockStatic(Uri.class);
         PowerMockito.mockStatic(IntentFactory.class);
         PowerMockito.mockStatic(PendingIntent.class);
+        PowerMockito.mockStatic(Arguments.class);
         PowerMockito.mockStatic(Log.class);
     }
 
     @Test
-    public void testConvertBundleToJSON() throws  Exception {
+    public void testConvertBundleToJSON() throws Exception {
         HashSet<String> keys = new HashSet<>(Arrays.asList("Key 1", "Key 2"));
         when(mBundle.keySet()).thenReturn(keys);
         when(mBundle.get("Key 1")).thenReturn("Value 1");
         when(mBundle.get("Key 2")).thenReturn("Value 2");
         String expectedJsonString = "{\"Key 1\":\"Value 1\",\"Key 2\":\"Value 2\"}";
 
-        JSONObject json = ReactNativeUtil.convertBundleToJSON(mBundle);
+        JSONObject json = convertBundleToJSON(mBundle);
 
         Assert.assertEquals(json.toString(), expectedJsonString);
     }
 
     @Test
+    public void testConvertBundleToMapNullArgument() {
+        WritableMap expectedMap = PowerMockito.mock(WritableMap.class);
+        when(Arguments.createMap()).thenReturn(expectedMap);
+
+        WritableMap map = convertBundleToMap(null);
+
+        Assert.assertEquals(map, expectedMap);
+        verify(expectedMap, times(0)).putNull(anyString());
+        verify(expectedMap, times(0)).putMap(anyString(), any());
+        verify(expectedMap, times(0)).putString(anyString(), anyString());
+        verify(expectedMap, times(0)).putDouble(anyString(), anyDouble());
+        verify(expectedMap, times(0)).putDouble(anyString(), anyFloat());
+        verify(expectedMap, times(0)).putInt(anyString(), anyInt());
+        verify(expectedMap, times(0)).putNull(anyString());
+    }
+
+    @Test
+    public void testConvertBundleToMap() {
+        final String key = "Key";
+        final HashSet<String> keys = new HashSet<>(Arrays.asList(key));
+
+        WritableMap expectedMap = PowerMockito.mock(WritableMap.class);
+        when(Arguments.createMap()).thenReturn(expectedMap);
+
+        when(mBundle.keySet()).thenReturn(keys);
+        when(mBundle.get(key)).thenReturn(null);
+        convertBundleToMap(mBundle);
+        verify(expectedMap, times(1)).putNull(key);
+
+        reset(expectedMap);
+        when(mBundle.keySet()).thenReturn(keys);
+        when(mBundle.get(key)).thenReturn(PowerMockito.mock(Bundle.class));
+        convertBundleToMap(mBundle);
+        verify(expectedMap, times(1)).putMap(eq(key), any(WritableMap.class));
+
+        reset(expectedMap);
+        when(mBundle.keySet()).thenReturn(keys);
+        final String strValue = "Value";
+        when(mBundle.get(key)).thenReturn(strValue);
+        convertBundleToMap(mBundle);
+        verify(expectedMap, times(1)).putString(key, strValue);
+
+        reset(expectedMap);
+        when(mBundle.keySet()).thenReturn(keys);
+        final Float floatValue = new Float(1);
+        when(mBundle.get(key)).thenReturn(floatValue);
+        convertBundleToMap(mBundle);
+        verify(expectedMap, times(1)).putDouble(key, floatValue.doubleValue());
+
+        reset(expectedMap);
+        when(mBundle.keySet()).thenReturn(keys);
+        final Double doubleValue = new Double(1);
+        when(mBundle.get(key)).thenReturn(doubleValue);
+        convertBundleToMap(mBundle);
+        verify(expectedMap, times(1)).putDouble(key, doubleValue);
+
+        reset(expectedMap);
+        when(mBundle.keySet()).thenReturn(keys);
+        final Integer integerValue = new Integer(1);
+        when(mBundle.get(key)).thenReturn(integerValue);
+        convertBundleToMap(mBundle);
+        verify(expectedMap, times(1)).putInt(key, integerValue);
+
+        reset(expectedMap);
+        when(mBundle.keySet()).thenReturn(keys);
+        final Long longValue = new Long(1);
+        when(mBundle.get(key)).thenReturn(longValue);
+        convertBundleToMap(mBundle);
+        verify(expectedMap, times(1)).putInt(key, longValue.intValue());
+
+        reset(expectedMap);
+        when(mBundle.keySet()).thenReturn(keys);
+        final Short shortValue = new Short("1");
+        when(mBundle.get(key)).thenReturn(shortValue);
+        convertBundleToMap(mBundle);
+        verify(expectedMap, times(1)).putInt(key, shortValue.intValue());
+
+        reset(expectedMap);
+        when(mBundle.keySet()).thenReturn(keys);
+        final Byte byteValue = new Byte("1");
+        when(mBundle.get(key)).thenReturn(byteValue);
+        convertBundleToMap(mBundle);
+        verify(expectedMap, times(1)).putInt(key, byteValue.intValue());
+
+        reset(expectedMap);
+        when(mBundle.keySet()).thenReturn(keys);
+        when(mBundle.get(key)).thenReturn(new HashMap<>());
+        convertBundleToMap(mBundle);
+        verify(expectedMap, times(1)).putNull(key);
+    }
+
+    @Test
     public void testCreateBroadcastIntent() throws Exception {
         final String action = "action";
-        final String jsonString = "{\"Key 1\":\"Value 1\",\"Key 2\":\"Value 2\"}";
-        final JSONObject json = new JSONObject(jsonString);
 
         Intent intent = PowerMockito.mock(Intent.class);
         when(IntentFactory.createIntent(action)).thenReturn(intent);
 
-        ReactNativeUtil.createBroadcastIntent(action, json);
+        createBroadcastIntent(action, mBundle);
 
         PowerMockito.verifyStatic(IntentFactory.class);
         IntentFactory.createIntent(action);
         verify(intent, times(1)).putExtra(
-                "event", DEVICE_NOTIF_EVENT);
-        verify(intent, times(1)).putExtra("data", jsonString);
+                KEY_INTENT_EVENT_NAME, EVENT_REMOTE_NOTIFICATION_RECEIVED);
+        verify(intent, times(1)).putExtra(
+                KEY_INTENT_EVENT_TYPE, INTENT_EVENT_TYPE_BUNDLE);
+        verify(intent, times(1)).putExtras(mBundle);
+    }
+
+    @Test
+    public void testEmitEventNoCatalystInstance() {
+        when(mReactApplicationContext.hasActiveCatalystInstance()).thenReturn(false);
+
+        emitEvent(mReactApplicationContext, "event", "data");
+
+        verify(mReactApplicationContext, times(1)).hasActiveCatalystInstance();
+        verify(mReactApplicationContext, times(0)).getJSModule(any());
+    }
+
+    @Test
+    public void testEmitEvent() {
+        when(mReactApplicationContext.hasActiveCatalystInstance()).thenReturn(true);
+        DeviceEventManagerModule.RCTDeviceEventEmitter emitter = PowerMockito.mock(
+                DeviceEventManagerModule.RCTDeviceEventEmitter.class);
+        when(mReactApplicationContext.getJSModule(any())).thenReturn(emitter);
+
+        emitEvent(mReactApplicationContext, "event", "data");
+
+        verify(mReactApplicationContext, times(1)).hasActiveCatalystInstance();
+        verify(mReactApplicationContext, times(1)).getJSModule(any());
+        verify(emitter, times(1)).emit("event", "data");
+    }
+
+    @Test
+    public void testEmitIntent() {
+        when(mReactApplicationContext.hasActiveCatalystInstance()).thenReturn(true);
+        DeviceEventManagerModule.RCTDeviceEventEmitter emitter = PowerMockito.mock(
+                DeviceEventManagerModule.RCTDeviceEventEmitter.class);
+        when(mReactApplicationContext.getJSModule(any())).thenReturn(emitter);
+        when(Arguments.createMap()).thenReturn(PowerMockito.mock(WritableMap.class));
+
+        Intent intent = PowerMockito.mock(Intent.class);
+        when(intent.getStringExtra(KEY_INTENT_EVENT_NAME)).thenReturn("event");
+        when(intent.getStringExtra(KEY_INTENT_EVENT_TYPE)).thenReturn(INTENT_EVENT_TYPE_BUNDLE);
+        when(intent.getExtras()).thenReturn(mBundle);
+        emitIntent(mReactApplicationContext, intent);
+        verify(mReactApplicationContext, times(1)).hasActiveCatalystInstance();
+        verify(mReactApplicationContext, times(1)).getJSModule(any());
+        verify(emitter, times(1)).emit(eq("event"), any(WritableMap.class));
+
+        reset(intent);
+        when(intent.getStringExtra(KEY_INTENT_EVENT_NAME)).thenReturn("event");
+        when(intent.getStringExtra(KEY_INTENT_EVENT_TYPE)).thenReturn(INTENT_EVENT_TYPE_STRING);
+        when(intent.getStringExtra(KEY_INTENT_EVENT_STRING_DATA)).thenReturn("data");
+        emitIntent(mReactApplicationContext, intent);
+        verify(mReactApplicationContext, times(2)).hasActiveCatalystInstance();
+        verify(mReactApplicationContext, times(2)).getJSModule(any());
+        verify(emitter, times(1)).emit("event", "data");
     }
 
     @Test
@@ -119,7 +273,7 @@ public class ReactNativeUtilTest {
         when(launchIntent.getComponent()).thenReturn(component);
         when(component.getClassName()).thenReturn(className);
 
-        Class activityClass = ReactNativeUtil.getMainActivityClass(mReactApplicationContext);
+        Class activityClass = getMainActivityClass(mReactApplicationContext);
 
         Assert.assertEquals(activityClass.getName(), className);
     }
@@ -137,26 +291,26 @@ public class ReactNativeUtilTest {
         when(launchIntent.getComponent()).thenReturn(component);
         when(component.getClassName()).thenReturn(className);
 
-        Class activityClass = ReactNativeUtil.getMainActivityClass(mReactApplicationContext);
+        Class activityClass = getMainActivityClass(mReactApplicationContext);
 
         Assert.assertNull(activityClass);
     }
 
     @Test
     public void testGetNotificationCompatPriority() {
-        Assert.assertEquals(ReactNativeUtil.getNotificationCompatPriority("max"), NotificationCompat.PRIORITY_MAX);
-        Assert.assertEquals(ReactNativeUtil.getNotificationCompatPriority("Max"), NotificationCompat.PRIORITY_MAX);
-        Assert.assertEquals(ReactNativeUtil.getNotificationCompatPriority("high"), NotificationCompat.PRIORITY_HIGH);
-        Assert.assertEquals(ReactNativeUtil.getNotificationCompatPriority("High"), NotificationCompat.PRIORITY_HIGH);
-        Assert.assertEquals(ReactNativeUtil.getNotificationCompatPriority("low"), NotificationCompat.PRIORITY_LOW);
-        Assert.assertEquals(ReactNativeUtil.getNotificationCompatPriority("Low"), NotificationCompat.PRIORITY_LOW);
-        Assert.assertEquals(ReactNativeUtil.getNotificationCompatPriority("min"), NotificationCompat.PRIORITY_MIN);
-        Assert.assertEquals(ReactNativeUtil.getNotificationCompatPriority("Min"), NotificationCompat.PRIORITY_MIN);
-        Assert.assertEquals(ReactNativeUtil.getNotificationCompatPriority("normal"), NotificationCompat.PRIORITY_DEFAULT);
-        Assert.assertEquals(ReactNativeUtil.getNotificationCompatPriority("Normal"), NotificationCompat.PRIORITY_DEFAULT);
-        Assert.assertEquals(ReactNativeUtil.getNotificationCompatPriority("default"), NotificationCompat.PRIORITY_DEFAULT);
-        Assert.assertEquals(ReactNativeUtil.getNotificationCompatPriority("Default"), NotificationCompat.PRIORITY_DEFAULT);
-        Assert.assertEquals(ReactNativeUtil.getNotificationCompatPriority(null), NotificationCompat.PRIORITY_DEFAULT);
+        Assert.assertEquals(getNotificationCompatPriority("max"), NotificationCompat.PRIORITY_MAX);
+        Assert.assertEquals(getNotificationCompatPriority("Max"), NotificationCompat.PRIORITY_MAX);
+        Assert.assertEquals(getNotificationCompatPriority("high"), NotificationCompat.PRIORITY_HIGH);
+        Assert.assertEquals(getNotificationCompatPriority("High"), NotificationCompat.PRIORITY_HIGH);
+        Assert.assertEquals(getNotificationCompatPriority("low"), NotificationCompat.PRIORITY_LOW);
+        Assert.assertEquals(getNotificationCompatPriority("Low"), NotificationCompat.PRIORITY_LOW);
+        Assert.assertEquals(getNotificationCompatPriority("min"), NotificationCompat.PRIORITY_MIN);
+        Assert.assertEquals(getNotificationCompatPriority("Min"), NotificationCompat.PRIORITY_MIN);
+        Assert.assertEquals(getNotificationCompatPriority("normal"), NotificationCompat.PRIORITY_DEFAULT);
+        Assert.assertEquals(getNotificationCompatPriority("Normal"), NotificationCompat.PRIORITY_DEFAULT);
+        Assert.assertEquals(getNotificationCompatPriority("default"), NotificationCompat.PRIORITY_DEFAULT);
+        Assert.assertEquals(getNotificationCompatPriority("Default"), NotificationCompat.PRIORITY_DEFAULT);
+        Assert.assertEquals(getNotificationCompatPriority(null), NotificationCompat.PRIORITY_DEFAULT);
     }
 
     @Test
@@ -171,7 +325,7 @@ public class ReactNativeUtilTest {
         when(res.getIdentifier(RESOURCE_NAME_LAUNCHER, RESOURCE_DEF_TYPE_MIPMAP, packageName))
                 .thenReturn(0);
 
-        int smallIconResId = ReactNativeUtil.getSmallIcon(mBundle, res, "Package Name");
+        int smallIconResId = getSmallIcon(mBundle, res, "Package Name");
 
         Assert.assertTrue(smallIconResId == expectedSmallIconResId);
         verify(mBundle, times(1)).getString(KEY_REMOTE_NOTIFICATION_SMALL_ICON);
@@ -191,7 +345,7 @@ public class ReactNativeUtilTest {
         when(res.getIdentifier(RESOURCE_NAME_LAUNCHER, RESOURCE_DEF_TYPE_MIPMAP, packageName))
                 .thenReturn(expectedSmallIconResId);
 
-        int smallIconResId = ReactNativeUtil.getSmallIcon(mBundle, res, "Package Name");
+        int smallIconResId = getSmallIcon(mBundle, res, "Package Name");
 
         Assert.assertTrue(smallIconResId == expectedSmallIconResId);
         verify(mBundle, times(1)).getString(KEY_REMOTE_NOTIFICATION_SMALL_ICON);
@@ -209,7 +363,7 @@ public class ReactNativeUtilTest {
         when(res.getIdentifier(RESOURCE_NAME_NOTIFICATION, RESOURCE_DEF_TYPE_MIPMAP, packageName))
                 .thenReturn(expectedSmallIconResId);
 
-        int smallIconResId = ReactNativeUtil.getSmallIcon(mBundle, res, "Package Name");
+        int smallIconResId = getSmallIcon(mBundle, res, "Package Name");
 
         Assert.assertTrue(smallIconResId == expectedSmallIconResId);
         verify(mBundle, times(1)).getString(KEY_REMOTE_NOTIFICATION_SMALL_ICON);
@@ -228,7 +382,7 @@ public class ReactNativeUtilTest {
         when(res.getIdentifier(smallIcon, RESOURCE_DEF_TYPE_MIPMAP, packageName))
                 .thenReturn(expectedSmallIconResId);
 
-        int smallIconResId = ReactNativeUtil.getSmallIcon(mBundle, res, "Package Name");
+        int smallIconResId = getSmallIcon(mBundle, res, "Package Name");
 
         Assert.assertTrue(smallIconResId == expectedSmallIconResId);
         verify(mBundle, times(1)).getString(KEY_REMOTE_NOTIFICATION_SMALL_ICON);
@@ -245,7 +399,7 @@ public class ReactNativeUtilTest {
         when(res.getIdentifier(RESOURCE_NAME_LAUNCHER, RESOURCE_DEF_TYPE_MIPMAP, packageName))
                 .thenReturn(expectedLargeIconResId);
 
-        int largeIconResId = ReactNativeUtil.getLargeIcon(mBundle, null, res, "Package Name");
+        int largeIconResId = getLargeIcon(mBundle, null, res, "Package Name");
 
         Assert.assertTrue(largeIconResId == expectedLargeIconResId);
         verify(res, times(1)).getIdentifier(RESOURCE_NAME_LAUNCHER, RESOURCE_DEF_TYPE_MIPMAP, packageName);
@@ -261,7 +415,7 @@ public class ReactNativeUtilTest {
         when(res.getIdentifier(largeIcon, RESOURCE_DEF_TYPE_MIPMAP, packageName))
                 .thenReturn(expectedLargeIconResId);
 
-        int largeIconResId = ReactNativeUtil.getLargeIcon(mBundle, largeIcon, res, "Package Name");
+        int largeIconResId = getLargeIcon(mBundle, largeIcon, res, "Package Name");
 
         Assert.assertTrue(largeIconResId == expectedLargeIconResId);
         verify(res, times(1)).getIdentifier(largeIcon, RESOURCE_DEF_TYPE_MIPMAP, packageName);
@@ -274,7 +428,7 @@ public class ReactNativeUtilTest {
         when(RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)).thenReturn(expectedSoundUri);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_SOUND_NAME)).thenReturn(null);
 
-        Uri soundUri = ReactNativeUtil.getSoundUri(mReactApplicationContext, mBundle);
+        Uri soundUri = getSoundUri(mReactApplicationContext, mBundle);
 
         Assert.assertEquals(soundUri, expectedSoundUri);
         verifyStatic(Uri.class, times(0));
@@ -289,7 +443,7 @@ public class ReactNativeUtilTest {
         when(RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)).thenReturn(expectedSoundUri);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_SOUND_NAME)).thenReturn(soundName);
 
-        Uri soundUri = ReactNativeUtil.getSoundUri(mReactApplicationContext, mBundle);
+        Uri soundUri = getSoundUri(mReactApplicationContext, mBundle);
 
         Assert.assertEquals(soundUri, expectedSoundUri);
         verifyStatic(Uri.class, times(0));
@@ -312,7 +466,7 @@ public class ReactNativeUtilTest {
         when(res.getIdentifier(rawSoundName, RESOURCE_DEF_TYPE_RAW, packageName)).thenReturn(soundResourceID);
         when(mReactApplicationContext.getResources()).thenReturn(res);
 
-        ReactNativeUtil.getSoundUri(mReactApplicationContext, mBundle);
+        getSoundUri(mReactApplicationContext, mBundle);
 
         verifyStatic(Uri.class);
         Uri.parse("android.resource://" + packageName + "/" + soundResourceID);
@@ -332,7 +486,7 @@ public class ReactNativeUtilTest {
         when(res.getIdentifier(soundName, RESOURCE_DEF_TYPE_RAW, packageName)).thenReturn(rawSoundResourceID);
         when(mReactApplicationContext.getResources()).thenReturn(res);
 
-        ReactNativeUtil.getSoundUri(mReactApplicationContext, mBundle);
+        getSoundUri(mReactApplicationContext, mBundle);
 
         verifyStatic(Uri.class);
         Uri.parse("android.resource://" + packageName + "/" + rawSoundResourceID);
@@ -343,7 +497,7 @@ public class ReactNativeUtilTest {
         Intent intent = PowerMockito.mock(Intent.class);
         when(IntentFactory.createIntent(eq(mReactApplicationContext), any())).thenReturn(intent);
 
-        ReactNativeUtil.createNotificationIntent(mReactApplicationContext, mBundle, null);
+        createNotificationIntent(mReactApplicationContext, mBundle, null);
 
         PowerMockito.verifyStatic(IntentFactory.class);
         IntentFactory.createIntent(mReactApplicationContext, null);
@@ -366,7 +520,7 @@ public class ReactNativeUtilTest {
         when(IntentFactory.createIntent()).thenReturn(intent);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ACTIONS)).thenReturn(null);
 
-        ReactNativeUtil.processNotificationActions(
+        processNotificationActions(
                 mReactApplicationContext, mBundle, notificationBuilder, notificationID);
 
         PowerMockito.verifyStatic(IntentFactory.class, times(0));
@@ -383,7 +537,7 @@ public class ReactNativeUtilTest {
         when(IntentFactory.createIntent()).thenReturn(intent);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ACTIONS)).thenReturn(jsonString);
 
-        ReactNativeUtil.processNotificationActions(
+        processNotificationActions(
                 mReactApplicationContext, mBundle, notificationBuilder, notificationID);
 
         PowerMockito.verifyStatic(IntentFactory.class, times(0));
@@ -402,7 +556,7 @@ public class ReactNativeUtilTest {
         when(IntentFactory.createIntent()).thenReturn(intent);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ACTIONS)).thenReturn(jsonString);
 
-        ReactNativeUtil.processNotificationActions(
+        processNotificationActions(
                 mReactApplicationContext, mBundle, notificationBuilder, notificationID);
 
         PowerMockito.verifyStatic(IntentFactory.class, times(0));
@@ -421,7 +575,7 @@ public class ReactNativeUtilTest {
         when(IntentFactory.createIntent()).thenReturn(intent);
         when(mBundle.getString(KEY_REMOTE_NOTIFICATION_ACTIONS)).thenReturn(jsonString);
 
-        ReactNativeUtil.processNotificationActions(
+        processNotificationActions(
                 mReactApplicationContext, mBundle, notificationBuilder, notificationID);
 
         PowerMockito.verifyStatic(IntentFactory.class, times(2));

--- a/sample/android/app/src/test/java/com/reactnativeazurenotificationhubsample/ReactNativeUtilTest.java
+++ b/sample/android/app/src/test/java/com/reactnativeazurenotificationhubsample/ReactNativeUtilTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import static com.azure.reactnative.notificationhub.ReactNativeNotificationHubUtil.*;
 import static com.azure.reactnative.notificationhub.ReactNativeConstants.*;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -113,6 +114,7 @@ public class ReactNativeUtilTest {
         verify(expectedMap, times(0)).putDouble(anyString(), anyDouble());
         verify(expectedMap, times(0)).putDouble(anyString(), anyFloat());
         verify(expectedMap, times(0)).putInt(anyString(), anyInt());
+        verify(expectedMap, times(0)).putBoolean(anyString(), anyBoolean());
         verify(expectedMap, times(0)).putNull(anyString());
     }
 
@@ -183,6 +185,13 @@ public class ReactNativeUtilTest {
         when(mBundle.get(key)).thenReturn(byteValue);
         convertBundleToMap(mBundle);
         verify(expectedMap, times(1)).putInt(key, byteValue.intValue());
+
+        reset(expectedMap);
+        when(mBundle.keySet()).thenReturn(keys);
+        final Boolean booleanValue = new Boolean(true);
+        when(mBundle.get(key)).thenReturn(booleanValue);
+        convertBundleToMap(mBundle);
+        verify(expectedMap, times(1)).putBoolean(key, booleanValue);
 
         reset(expectedMap);
         when(mBundle.keySet()).thenReturn(keys);


### PR DESCRIPTION
**Improvements**:

- Notifications received by subscribing `remoteNotificationReceived` event are now JSON objects instead of strings.
- Channel's name can now be set when registering.
- Notification payload now includes `avatarUrl` field that can be used to [set a notification's large icon](https://developer.android.com/reference/android/app/Notification.Builder#setLargeIcon(android.graphics.Bitmap)) from a remote image.

**Bug fixes**:

- Both `data` and `notification` payload types are now probably handled.

This will fix #118 #119 #120 #121 after landing.