### PR TITLE
Integrate new features and improvements from Mixer

### DIFF
--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeConstants.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeConstants.java
@@ -22,6 +22,9 @@ public final class ReactNativeConstants {
     public static final String KEY_REGISTRATION_CHANNELSHOWBADGE = "channelShowBadge";
     public static final String KEY_REGISTRATION_CHANNELENABLELIGHTS = "channelEnableLights";
     public static final String KEY_REGISTRATION_CHANNELENABLEVIBRATION = "channelEnableVibration";
+    public static final String KEY_REGISTRATION_TEMPLATENAME = "templateName";
+    public static final String KEY_REGISTRATION_TEMPLATE = "template";
+    public static final String KEY_REGISTRATION_ISTEMPLATE = "isTemplate";
 
     // Shared prefs used in NotificationHubUtil
     public static final String SHARED_PREFS_NAME = "com.azure.reactnative.notificationhub.NotificationHubUtil";
@@ -36,6 +39,10 @@ public final class ReactNativeConstants {
     public static final String KEY_FOR_PREFS_CHANNELSHOWBADGE = "AzureNotificationHub_channelShowBadge";
     public static final String KEY_FOR_PREFS_CHANNELENABLELIGHTS = "AzureNotificationHub_channelEnableLights";
     public static final String KEY_FOR_PREFS_CHANNELENABLEVIBRATION = "AzureNotificationHub_channelEnableVibration";
+    public static final String KEY_FOR_PREFS_TEMPLATENAME = "AzureNotificationHub_templateName";
+    public static final String KEY_FOR_PREFS_TEMPLATE = "AzureNotificationHub_template";
+    public static final String KEY_FOR_PREFS_ISTEMPLATE = "AzureNotificationHub_isTemplate";
+    public static final String KEY_FOR_PREFS_UUID = "AzureNotificationHub_UUID";
 
     // Remote notification payload
     public static final String KEY_REMOTE_NOTIFICATION_MESSAGE = "message";
@@ -85,6 +92,10 @@ public final class ReactNativeConstants {
     public static final String RESOURCE_NAME_NOTIFICATION = "ic_notification";
     public static final String RESOURCE_NAME_LAUNCHER = "ic_launcher";
 
+    // Promise
+    public static final String KEY_PROMISE_RESOLVE_UUID = "uuid";
+    public static final String AZURE_NOTIFICATION_HUB_UNREGISTERED = "Unregistered successfully";
+
     // Errors
     public static final String ERROR_NO_ACTIVITY_CLASS = "No activity class found for the notification";
     public static final String ERROR_NO_MESSAGE = "No message specified for the notification";
@@ -96,6 +107,8 @@ public final class ReactNativeConstants {
     public static final String ERROR_INVALID_CONNECTION_STRING = "Connection string cannot be null.";
     public static final String ERROR_INVALID_HUBNAME = "Hub name cannot be null.";
     public static final String ERROR_INVALID_SENDER_ID = "Sender ID cannot be null.";
+    public static final String ERROR_INVALID_TEMPLATE_NAME = "Template Name cannot be null.";
+    public static final String ERROR_INVALID_TEMPLATE = "Template cannot be null.";
     public static final String ERROR_PLAY_SERVICES = "E_PLAY_SERVICES";
     public static final String ERROR_PLAY_SERVICES_DISABLED = "User must enable Google Play Services.";
     public static final String ERROR_PLAY_SERVICES_UNSUPPORTED = "This device is not supported by Google Play Services.";
@@ -103,6 +116,12 @@ public final class ReactNativeConstants {
     public static final String ERROR_NOT_REGISTERED = "E_NOT_REGISTERED";
     public static final String ERROR_NOT_REGISTERED_DESC = "No registration to Azure Notification Hub.";
     public static final String ERROR_FETCH_IMAGE = "Error while fetching image.";
+    public static final String ERROR_GET_INIT_NOTIFICATION = "E_GET_INIT_NOTIF";
+    public static final String ERROR_ACTIVITY_IS_NULL = "Current activity is null";
+    public static final String ERROR_INTENT_EXTRAS_IS_NULL = "Intent get extras is null";
+    public static final String ERROR_ACTIVITY_INTENT_IS_NULL = "Activity intent is null";
+    public static final String ERROR_GET_UUID = "E_GET_UUID";
+    public static final String ERROR_NO_UUID_SET = "No uuid set";
 
     private ReactNativeConstants() {
     }

--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeNotificationHubUtil.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeNotificationHubUtil.java
@@ -165,6 +165,38 @@ public class ReactNativeNotificationHubUtil {
         return hasKey(context, KEY_FOR_PREFS_CHANNELENABLEVIBRATION);
     }
 
+    public String getTemplateName(Context context) {
+        return getPref(context, KEY_FOR_PREFS_TEMPLATENAME);
+    }
+
+    public void setTemplateName(Context context, String templateName) {
+        setPref(context, KEY_FOR_PREFS_TEMPLATENAME, templateName);
+    }
+
+    public String getTemplate(Context context) {
+        return getPref(context, KEY_FOR_PREFS_TEMPLATE);
+    }
+
+    public void setTemplate(Context context, String template) {
+        setPref(context, KEY_FOR_PREFS_TEMPLATE, template);
+    }
+
+    public boolean isTemplated(Context context) {
+        return getPrefBoolean(context, KEY_FOR_PREFS_ISTEMPLATE);
+    }
+
+    public void setTemplated(Context context, boolean templated) {
+        setPrefBoolean(context, KEY_FOR_PREFS_ISTEMPLATE, templated);
+    }
+
+    public String getUUID(Context context) {
+        return getPref(context, KEY_FOR_PREFS_UUID);
+    }
+
+    public void setUUID(Context context, String uuid) {
+        setPref(context, KEY_FOR_PREFS_UUID, uuid);
+    }
+
     public void setAppIsForeground(boolean isForeground) {
         mIsForeground = isForeground;
     }

--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeRegistrationIntentService.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeRegistrationIntentService.java
@@ -38,6 +38,9 @@ public class ReactNativeRegistrationIntentService extends JobIntentService {
         final String hubName = notificationHubUtil.getHubName(this);
         final String storedToken = notificationHubUtil.getFCMToken(this);
         final String[] tags = notificationHubUtil.getTags(this);
+        final boolean isTemplated = notificationHubUtil.isTemplated(this);
+        final String templateName = notificationHubUtil.getTemplateName(this);
+        final String template = notificationHubUtil.getTemplate(this);
 
         if (connectionString == null || hubName == null) {
             // The intent was triggered when no connection string has been set.
@@ -63,7 +66,13 @@ public class ReactNativeRegistrationIntentService extends JobIntentService {
                                         ReactNativeRegistrationIntentService.this);
                                 Log.d(TAG, "NH Registration refreshing with token : " + token);
 
-                                regID = hub.register(token, tags).getRegistrationId();
+                                if (isTemplated) {
+                                    regID = hub.registerTemplate(
+                                            token, templateName, template, tags).getRegistrationId();
+                                } else {
+                                    regID = hub.register(token, tags).getRegistrationId();
+                                }
+
                                 Log.d(TAG, "New NH Registration Successfully - RegId : " + regID);
 
                                 notificationHubUtil.setRegistrationID(ReactNativeRegistrationIntentService.this, regID);

--- a/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeUtil.java
+++ b/android/src/main/java/com/azure/reactnative/notificationhub/ReactNativeUtil.java
@@ -26,9 +26,9 @@ import org.json.JSONObject;
 
 import java.io.InputStream;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -333,6 +333,10 @@ public final class ReactNativeUtil {
             Log.e(TAG, ERROR_FETCH_IMAGE, e);
             return null;
         }
+    }
+
+    public static String genUUID() {
+        return UUID.randomUUID().toString();
     }
 
     private ReactNativeUtil() {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,10 +42,6 @@ steps:
   displayName: 'Run lint'
   workingDirectory: '../sample'
 
-- script: npm run test
-  displayName: 'Run unit tests'
-  workingDirectory: '../sample'
-
 - task: Gradle@2
   displayName: 'Building Android'
   inputs:
@@ -78,6 +74,7 @@ steps:
 
 - script: |
     pod install
+    pod update
     sudo cp -R ../node_modules/react-native-azurenotificationhub/ios Pods/RNAzureNotificationHub
     sudo chown -R $(id -u):$(id -g) Pods/RNAzureNotificationHub
     pod update

--- a/docs/android-installation.md
+++ b/docs/android-installation.md
@@ -203,6 +203,9 @@ const channelImportance = 3;          // The channel's importance (NotificationM
 const channelShowBadge = true;
 const channelEnableLights = true;
 const channelEnableVibration = true;
+const template = '...';               // Notification hub templates:
+                                      // https://docs.microsoft.com/en-us/azure/notification-hubs/notification-hubs-templates-cross-platform-push-messages
+const templateName = '...';           // The template's name
 
 export default class App extends Component {
   constructor(props) {
@@ -213,7 +216,7 @@ export default class App extends Component {
   register() {
     PushNotificationEmitter.addListener(EVENT_AZURE_NOTIFICATION_HUB_REGISTERED, this._onAzureNotificationHubRegistered);
     PushNotificationEmitter.addListener(EVENT_AZURE_NOTIFICATION_HUB_REGISTERED_ERROR, this._onAzureNotificationHubRegisteredError);
-  
+
     NotificationHub.register({
       connectionString,
       hubName,
@@ -225,12 +228,59 @@ export default class App extends Component {
       channelEnableLights,
       channelEnableVibration
     })
+    .then((res) => console.warn(res))
+    .catch(reason => console.warn(reason));
+  }
+
+  registerTemplate() {
+    PushNotificationEmitter.addListener(EVENT_AZURE_NOTIFICATION_HUB_REGISTERED, this._onAzureNotificationHubRegistered);
+    PushNotificationEmitter.addListener(EVENT_AZURE_NOTIFICATION_HUB_REGISTERED_ERROR, this._onAzureNotificationHubRegisteredError);
+
+    NotificationHub.registerTemplate({
+      connectionString,
+      hubName,
+      senderID,
+      template,
+      templateName,
+      tags,
+      channelName,
+      channelImportance,
+      channelShowBadge,
+      channelEnableLights,
+      channelEnableVibration
+    })
+    .then((res) => console.warn(res))
+    .catch(reason => console.warn(reason));
+  }
+
+  getInitialNotification() {
+    NotificationHub.getInitialNotification()
+    .then((res) => console.warn(res))
+    .catch(reason => console.warn(reason));
+  }
+
+  getUUID() {
+    NotificationHub.getUUID(false)
+    .then((res) => console.warn(res))
+    .catch(reason => console.warn(reason));
+  }
+
+  isNotificationEnabledOnOSLevel() {
+    NotificationHub.isNotificationEnabledOnOSLevel()
+    .then((res) => console.warn(res))
     .catch(reason => console.warn(reason));
   }
 
   unregister() {
     NotificationHub.unregister()
-      .catch(reason => console.warn(reason));
+    .then((res) => console.warn(res))
+    .catch(reason => console.warn(reason));
+  }
+
+  unregisterTemplate() {
+    NotificationHub.unregisterTemplate(templateName)
+    .then((res) => console.warn(res))
+    .catch(reason => console.warn(reason));
   }
 
   render() {
@@ -240,28 +290,63 @@ export default class App extends Component {
          <View style={styles.button}>
            <Text style={styles.buttonText}>
              Register
-           </Text> 
+           </Text>
+         </View>
+       </TouchableOpacity>
+       <TouchableOpacity onPress={this.registerTemplate.bind(this)}>
+         <View style={styles.button}>
+           <Text style={styles.buttonText}>
+             Register Template
+           </Text>
+         </View>
+       </TouchableOpacity>
+       <TouchableOpacity onPress={this.getInitialNotification.bind(this)}>
+         <View style={styles.button}>
+           <Text style={styles.buttonText}>
+            Get initial notification
+           </Text>
+         </View>
+       </TouchableOpacity>
+       <TouchableOpacity onPress={this.getUUID.bind(this)}>
+         <View style={styles.button}>
+           <Text style={styles.buttonText}>
+            Get UUID
+           </Text>
+         </View>
+       </TouchableOpacity>
+       <TouchableOpacity onPress={this.isNotificationEnabledOnOSLevel.bind(this)}>
+         <View style={styles.button}>
+           <Text style={styles.buttonText}>
+            Check if notification is enabled
+           </Text>
          </View>
        </TouchableOpacity>
        <TouchableOpacity onPress={this.unregister.bind(this)}>
          <View style={styles.button}>
            <Text style={styles.buttonText}>
              Unregister
-           </Text> 
+           </Text>
+         </View>
+       </TouchableOpacity>
+       <TouchableOpacity onPress={this.unregisterTemplate.bind(this)}>
+         <View style={styles.button}>
+           <Text style={styles.buttonText}>
+             Unregister Template
+           </Text>
          </View>
        </TouchableOpacity>
       </View>
     );
   }
-  
+
   _onAzureNotificationHubRegistered(registrationID) {
     console.warn('RegistrationID: ' + registrationID);
   }
-  
+
   _onAzureNotificationHubRegisteredError(error) {
     console.warn('Error: ' + error);
   }
-  
+
   _onRemoteNotification(notification) {
     console.warn(notification);
   }

--- a/ios/AzureNotificationHubIOS.js
+++ b/ios/AzureNotificationHubIOS.js
@@ -357,12 +357,20 @@ class AzureNotificationHubIOS {
     RCTAzureNotificationHubManager.checkPermissions(callback);
   }
 
-  static register(deviceToken, config) {
-    RCTAzureNotificationHubManager.register(deviceToken, config);
+  static register(deviceToken, config): Promise<string | Object> {
+    return RCTAzureNotificationHubManager.register(deviceToken, config);
   }
 
-  static unregister() {
-    RCTAzureNotificationHubManager.unregister();
+  static registerTemplate(deviceToken, config): Promise<string | Object> {
+    return RCTAzureNotificationHubManager.registerTemplate(deviceToken, config);
+  }
+
+  static unregister(): Promise<string | Object> {
+    return RCTAzureNotificationHubManager.unregister();
+  }
+
+  static unregisterTemplate(templateName): Promise<string | Object> {
+    return RCTAzureNotificationHubManager.unregisterTemplate(templateName);
   }
 
   /**

--- a/ios/RCTAzureNotificationHubManager/RCTAzureNotificationHandler.h
+++ b/ios/RCTAzureNotificationHubManager/RCTAzureNotificationHandler.h
@@ -35,9 +35,6 @@
 // Handle registration error for Azure Notification Hub
 - (void)azureNotificationHubRegisteredError:(nonnull NSNotification *)notification;
 
-// Handle successful registration for UIUserNotificationSettings
-- (void)userNotificationSettingsRegistered:(nonnull NSNotification *)notification;
-
 @end
 
 #endif /* RCTAzureNotificationHandler_h */

--- a/ios/RCTAzureNotificationHubManager/RCTAzureNotificationHandler.m
+++ b/ios/RCTAzureNotificationHubManager/RCTAzureNotificationHandler.m
@@ -10,8 +10,6 @@
 #import "RCTAzureNotificationHub.h"
 #import "RCTAzureNotificationHandler.h"
 
-extern RCTPromiseResolveBlock requestPermissionsResolveBlock;
-
 @implementation RCTAzureNotificationHandler
 {
 @private
@@ -90,26 +88,6 @@ extern RCTPromiseResolveBlock requestPermissionsResolveBlock;
     
     [_eventEmitter sendEventWithName:RCTAzureNotificationHubRegisteredError
                                 body:errorDetails];
-}
-
-// Handle successful registration for UIUserNotificationSettings
-- (void)userNotificationSettingsRegistered:(nonnull NSNotification *)notification
-{
-    RCTPromiseResolveBlock resolve = notification.userInfo[RCTUserInfoResolveBlock];
-    if (resolve == nil)
-    {
-        return;
-    }
-    
-    UIUserNotificationSettings *notificationSettings = notification.userInfo[RCTUserInfoNotificationSettings];
-    NSDictionary *notificationTypes = @{
-        RCTNotificationTypeAlert: @((notificationSettings.types & UIUserNotificationTypeAlert) > 0),
-        RCTNotificationTypeSound: @((notificationSettings.types & UIUserNotificationTypeSound) > 0),
-        RCTNotificationTypeBadge: @((notificationSettings.types & UIUserNotificationTypeBadge) > 0),
-    };
-    
-    resolve(notificationTypes);
-    requestPermissionsResolveBlock = nil;
 }
 
 @end

--- a/ios/RCTAzureNotificationHubManager/RCTAzureNotificationHub.h
+++ b/ios/RCTAzureNotificationHubManager/RCTAzureNotificationHub.h
@@ -10,6 +10,8 @@
 #ifndef RCTAzureNotificationHub_h
 #define RCTAzureNotificationHub_h
 
+@import UserNotifications;
+
 // Notification Hub events
 extern NSString *const RCTLocalNotificationReceived;
 extern NSString *const RCTRemoteNotificationReceived;
@@ -23,9 +25,10 @@ extern NSString *const RCTUserNotificationSettingsRegistered;
 extern NSString *const RCTConnectionStringKey;
 extern NSString *const RCTHubNameKey;
 extern NSString *const RCTTagsKey;
+extern NSString *const RCTTemplateNameKey;
+extern NSString *const RCTTemplateKey;
 
 // User info
-extern NSString *const RCTUserInfoNotificationSettings;
 extern NSString *const RCTUserInfoDeviceToken;
 extern NSString *const RCTUserInfoRemote;
 extern NSString *const RCTUserInfoResolveBlock;
@@ -38,15 +41,25 @@ extern NSString *const RCTNotificationTypeBadge;
 extern NSString *const RCTNotificationTypeSound;
 extern NSString *const RCTNotificationTypeAlert;
 
+// Messages
+extern NSString *const RCTPromiseResolveUnregiseredSuccessfully;
+
 // Errors
 extern NSString *const RCTErrorUnableToRequestPermissions;
-extern NSString *const RCTErrorUnableToRequestPermissionsDetails;
+extern NSString *const RCTErrorUnableToRequestPermissionsAppExt;
 extern NSString *const RCTErrorUnableToRequestPermissionsTwice;
+extern NSString *const RCTErrorUnableToRequestPermissionsUserReject;
 extern NSString *const RCTErrorInvalidArguments;
 extern NSString *const RCTErrorMissingConnectionString;
 extern NSString *const RCTErrorMissingHubName;
+extern NSString *const RCTErrorMissingTemplateName;
+extern NSString *const RCTErrorMissingTemplate;
+extern NSString *const RCTErrorUnableToUnregister;
+extern NSString *const RCTErrorUnableToUnregisterNoRegistration;
 
-// Completion type used in Azure Notification Hub's native methods
+// Completion types
 typedef void (^RCTNativeCompletion)(NSError *error);
+typedef void (^RCTNotificationCompletion)(BOOL granted, NSError * _Nullable error);
+typedef void (^RCTNotificationSettingsCompletion)(UNNotificationSettings * _Nonnull settings);
 
 #endif /* RCTAzureNotificationHub_h */

--- a/ios/RCTAzureNotificationHubManager/RCTAzureNotificationHub.m
+++ b/ios/RCTAzureNotificationHubManager/RCTAzureNotificationHub.m
@@ -20,9 +20,10 @@ NSString *const RCTUserNotificationSettingsRegistered           = @"userNotifica
 NSString *const RCTConnectionStringKey                          = @"connectionString";
 NSString *const RCTHubNameKey                                   = @"hubName";
 NSString *const RCTTagsKey                                      = @"tags";
+NSString *const RCTTemplateNameKey                              = @"templateName";
+NSString *const RCTTemplateKey                                  = @"template";
 
 // User info
-NSString *const RCTUserInfoNotificationSettings                 = @"notificationSettings";
 NSString *const RCTUserInfoDeviceToken                          = @"deviceToken";
 NSString *const RCTUserInfoRemote                               = @"remote";
 NSString *const RCTUserInfoResolveBlock                         = @"resolveBlock";
@@ -35,10 +36,18 @@ NSString *const RCTNotificationTypeBadge                        = @"badge";
 NSString *const RCTNotificationTypeSound                        = @"sound";
 NSString *const RCTNotificationTypeAlert                        = @"alert";
 
+// Messages
+NSString *const RCTPromiseResolveUnregiseredSuccessfully        = @"Unregisted successfully";
+
 // Errors
 NSString *const RCTErrorUnableToRequestPermissions              = @"Unabled to request permissions";
-NSString *const RCTErrorUnableToRequestPermissionsDetails       = @"Requesting push notifications is currently unavailable in an app extension";
+NSString *const RCTErrorUnableToRequestPermissionsAppExt        = @"Requesting push notifications is currently unavailable in an app extension.";
 NSString *const RCTErrorUnableToRequestPermissionsTwice         = @"Cannot call requestPermissions twice before the first has returned.";
+NSString *const RCTErrorUnableToRequestPermissionsUserReject    = @"User didn't allow permissions.";
 NSString *const RCTErrorInvalidArguments                        = @"Invalid arguments";
 NSString *const RCTErrorMissingConnectionString                 = @"Connection string cannot be null.";
 NSString *const RCTErrorMissingHubName                          = @"Hub name cannot be null.";
+NSString *const RCTErrorMissingTemplateName                     = @"Template name cannot be null.";
+NSString *const RCTErrorMissingTemplate                         = @"Template cannot be null.";
+NSString *const RCTErrorUnableToUnregister                      = @"Unabled to unregister";
+NSString *const RCTErrorUnableToUnregisterNoRegistration        = @"There is no registration.";

--- a/ios/RCTAzureNotificationHubManager/RCTAzureNotificationHubManager.h
+++ b/ios/RCTAzureNotificationHubManager/RCTAzureNotificationHubManager.h
@@ -9,22 +9,26 @@
 
 #import "React/RCTEventEmitter.h"
 
+#import "RCTAzureNotificationHandler.h"
+
+@import UserNotifications;
+
 @interface RCTAzureNotificationHubManager : RCTEventEmitter
 
-// Required to register for notifications, invoked from AppDelegate
-+ (void)didRegisterUserNotificationSettings:(nonnull UIUserNotificationSettings *)notificationSettings;
-
-// Required for the register event, invoked from AppDelegate
+// Invoked from AppDelegate when the app successfully registered with Apple Push Notification service (APNs).
 + (void)didRegisterForRemoteNotificationsWithDeviceToken:(nonnull NSData *)deviceToken;
 
-// Required for the notification event, invoked from AppDelegate
-+ (void)didReceiveRemoteNotification:(nonnull NSDictionary *)notification;
-
-// Required for the localNotification event, invoked from AppDelegate
-+ (void)didReceiveLocalNotification:(nonnull UILocalNotification *)notification;
-
-// Required for the registrationError event, invoked from AppDelegate
+// Invoked from AppDelegate when APNs cannot successfully complete the registration process.
 + (void)didFailToRegisterForRemoteNotificationsWithError:(nonnull NSError *)error;
+
+// Invoked from AppDelegate when a remote notification arrived and there is data to be fetched.
++ (void)didReceiveRemoteNotification:(nonnull NSDictionary *)userInfo
+              fetchCompletionHandler:(void (__unused ^_Nonnull)(UIBackgroundFetchResult result))completionHandler;
+
+// Invoked from AppDelegate when a notification arrived while the app was running in the foreground.
++ (void)userNotificationCenter:(nonnull __unused UNUserNotificationCenter *)center
+       willPresentNotification:(nonnull UNNotification *)notification
+         withCompletionHandler:(void (__unused ^_Nonnull)(UNNotificationPresentationOptions options))completionHandler;
 
 // Set application icon badge number
 - (void)setApplicationIconBadgeNumber:(NSInteger)number;
@@ -65,11 +69,25 @@
 // Register with Azure Notification Hub
 - (void)register:(nonnull NSString *)deviceToken
           config:(nonnull NSDictionary *)config
-        resolver:(nonnull RCTPromiseResolveBlock)resolve
+        resolver:(nonnull __unused RCTPromiseResolveBlock)resolve
         rejecter:(nonnull RCTPromiseRejectBlock)reject;
+
+// Register template
+- (void)registerTemplate:(nonnull NSString *)deviceToken
+                  config:(nonnull NSDictionary *)config
+                resolver:(nonnull __unused RCTPromiseResolveBlock)resolve
+                rejecter:(nonnull RCTPromiseRejectBlock)reject;
 
 // Unregister with Azure Notification Hub
 - (void)unregister:(nonnull RCTPromiseResolveBlock)resolve
           rejecter:(nonnull RCTPromiseRejectBlock)reject;
+
+// Unregister template
+- (void)unregisterTemplate:(nonnull NSString *)templateName
+                  resolver:(nonnull RCTPromiseResolveBlock)resolve
+                  rejecter:(nonnull RCTPromiseRejectBlock)reject;
+
+// Set notification handler
+- (void)setNotificationHandler:(nonnull RCTAzureNotificationHandler *)handler;
 
 @end

--- a/ios/RCTAzureNotificationHubManager/RCTAzureNotificationHubManager.m
+++ b/ios/RCTAzureNotificationHubManager/RCTAzureNotificationHubManager.m
@@ -312,7 +312,7 @@ RCT_EXPORT_METHOD(getScheduledLocalNotifications:(RCTResponseSenderBlock)callbac
 
 RCT_EXPORT_METHOD(register:(nonnull NSString *)deviceToken
                     config:(nonnull NSDictionary *)config
-                  resolver:(__unused RCTPromiseResolveBlock)resolve
+                  resolver:(nonnull __unused RCTPromiseResolveBlock)resolve
                   rejecter:(nonnull RCTPromiseRejectBlock)reject)
 {
     // Store the connection string, hub name and tags
@@ -365,7 +365,7 @@ RCT_EXPORT_METHOD(registerTemplate:(nonnull NSString *)deviceToken
                           resolver:(nonnull __unused RCTPromiseResolveBlock)resolve
                           rejecter:(nonnull RCTPromiseRejectBlock)reject)
 {
-    // Store the connection string, hub name and tags
+    // Store the connection string, hub name, tags, template name and template
     _connectionString = [config objectForKey:RCTConnectionStringKey];
     _hubName = [config objectForKey:RCTHubNameKey];
     _tags = [config objectForKey:RCTTagsKey];

--- a/ios/RCTAzureNotificationHubManager/RCTAzureNotificationHubUtil.h
+++ b/ios/RCTAzureNotificationHubManager/RCTAzureNotificationHubUtil.h
@@ -12,7 +12,12 @@
 
 #import <WindowsAzureMessaging/WindowsAzureMessaging.h>
 
+@import UserNotifications;
+
 @interface RCTAzureNotificationHubUtil : NSObject
+
+// Format UNNotification
++ (nonnull NSDictionary *)formatUNNotification:(nonnull UNNotification *)notification;
 
 // Format local notification
 + (nonnull NSDictionary *)formatLocalNotification:(nonnull UILocalNotification *)notification;
@@ -25,10 +30,10 @@
 + (nonnull NSString *)convertDeviceTokenToString:(nonnull NSData *)deviceToken;
 
 // Get notification types with permissions
-+ (UIUserNotificationType)getNotificationTypesWithPermissions:(nullable NSDictionary *)permissions;
++ (UNAuthorizationOptions)getNotificationTypesWithPermissions:(nullable NSDictionary *)permissions;
 
 // Run block on the main thread
-+ (void)runOnMainThread:(dispatch_block_t)block;
++ (void)runOnMainThread:(nonnull dispatch_block_t)block;
 
 @end
 

--- a/ios/RCTAzureNotificationHubManager/RCTAzureNotificationHubUtil.m
+++ b/ios/RCTAzureNotificationHubManager/RCTAzureNotificationHubUtil.m
@@ -15,6 +15,33 @@
 
 @implementation RCTAzureNotificationHubUtil
 
+// Format UNNotification
++ (nonnull NSDictionary *)formatUNNotification:(nonnull UNNotification *)notification
+{
+    NSMutableDictionary *formattedNotification = [NSMutableDictionary dictionary];
+    UNNotificationContent *content = notification.request.content;
+
+    formattedNotification[@"identifier"] = notification.request.identifier;
+
+    if (notification.date)
+    {
+        NSDateFormatter *formatter = [NSDateFormatter new];
+        [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"];
+        NSString *dateString = [formatter stringFromDate:notification.date];
+        formattedNotification[@"date"] = dateString;
+    }
+
+    formattedNotification[@"title"] = RCTNullIfNil(content.title);
+    formattedNotification[@"thread-id"] = RCTNullIfNil(content.threadIdentifier);
+    formattedNotification[@"alertBody"] = RCTNullIfNil(content.body);
+    formattedNotification[@"applicationIconBadgeNumber"] = RCTNullIfNil(content.badge);
+    formattedNotification[@"category"] = RCTNullIfNil(content.categoryIdentifier);
+    formattedNotification[@"soundName"] = RCTNullIfNil(content.sound);
+    formattedNotification[@"userInfo"] = RCTNullIfNil(RCTJSONClean(content.userInfo));
+
+    return formattedNotification;
+}
+
 // Format local notification
 + (nonnull NSDictionary *)formatLocalNotification:(nonnull UILocalNotification *)notification
 {
@@ -26,7 +53,7 @@
         NSString *fireDateString = [formatter stringFromDate:notification.fireDate];
         formattedLocalNotification[@"fireDate"] = fireDateString;
     }
-    
+
     formattedLocalNotification[@"alertAction"] = RCTNullIfNil(notification.alertAction);
     formattedLocalNotification[@"alertBody"] = RCTNullIfNil(notification.alertBody);
     formattedLocalNotification[@"applicationIconBadgeNumber"] = @(notification.applicationIconBadgeNumber);
@@ -62,36 +89,36 @@
 }
 
 // Get notification types with permissions
-+ (UIUserNotificationType)getNotificationTypesWithPermissions:(nullable NSDictionary *)permissions
++ (UNAuthorizationOptions)getNotificationTypesWithPermissions:(nullable NSDictionary *)permissions
 {
-    UIUserNotificationType types = UIUserNotificationTypeNone;
+    UNAuthorizationOptions types = 0;
     if (permissions)
     {
         if ([RCTConvert BOOL:permissions[RCTNotificationTypeAlert]])
         {
-            types |= UIUserNotificationTypeAlert;
+            types |= UNAuthorizationOptionAlert;
         }
         
         if ([RCTConvert BOOL:permissions[RCTNotificationTypeBadge]])
         {
-            types |= UIUserNotificationTypeBadge;
+            types |= UNAuthorizationOptionBadge;
         }
         
         if ([RCTConvert BOOL:permissions[RCTNotificationTypeSound]])
         {
-            types |= UIUserNotificationTypeSound;
+            types |= UNAuthorizationOptionSound;
         }
     }
     else
     {
-        types = UIUserNotificationTypeAlert | UIUserNotificationTypeBadge | UIUserNotificationTypeSound;
+        types = UNAuthorizationOptionAlert | UNAuthorizationOptionBadge | UNAuthorizationOptionSound;
     }
     
     return types;
 }
 
 // Run block on the main thread
-+ (void)runOnMainThread:(dispatch_block_t)block
++ (void)runOnMainThread:(nonnull dispatch_block_t)block
 {
     dispatch_async(dispatch_get_main_queue(), block);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-azurenotificationhub",
-  "version": "0.9.4-Patched.1",
+  "version": "0.9.5",
   "description": "React Native module to support Azure Notification Hub push notifications on Android, iOS, and Windows.",
   "main": "index.js",
   "repository": {

--- a/sample/App.js
+++ b/sample/App.js
@@ -6,109 +6,194 @@
  * @flow
  */
 
-import React from 'react';
+import React, { Component } from 'react';
+import { NativeEventEmitter } from 'react-native';
 import {
-  SafeAreaView,
   StyleSheet,
-  ScrollView,
-  View,
   Text,
-  StatusBar,
+  View,
+  TouchableOpacity,
 } from 'react-native';
 
-import {
-  Header,
-  LearnMoreLinks,
-  Colors,
-  DebugInstructions,
-  ReloadInstructions,
-} from 'react-native/Libraries/NewAppScreen';
+const NotificationHub = require('react-native-azurenotificationhub');
+const PushNotificationEmitter = new NativeEventEmitter(NotificationHub);
 
-const App: () => React$Node = () => {
-  return (
-    <>
-      <StatusBar barStyle="dark-content" />
-      <SafeAreaView>
-        <ScrollView
-          contentInsetAdjustmentBehavior="automatic"
-          style={styles.scrollView}>
-          <Header />
-          {global.HermesInternal == null ? null : (
-            <View style={styles.engine}>
-              <Text style={styles.footer}>Engine: Hermes</Text>
-            </View>
-          )}
-          <View style={styles.body}>
-            <View style={styles.sectionContainer}>
-              <Text style={styles.sectionTitle}>Step One</Text>
-              <Text style={styles.sectionDescription}>
-                Edit <Text style={styles.highlight}>App.js</Text> to change this
-                screen and then come back to see your edits.
-              </Text>
-            </View>
-            <View style={styles.sectionContainer}>
-              <Text style={styles.sectionTitle}>See Your Changes</Text>
-              <Text style={styles.sectionDescription}>
-                <ReloadInstructions />
-              </Text>
-            </View>
-            <View style={styles.sectionContainer}>
-              <Text style={styles.sectionTitle}>Debug</Text>
-              <Text style={styles.sectionDescription}>
-                <DebugInstructions />
-              </Text>
-            </View>
-            <View style={styles.sectionContainer}>
-              <Text style={styles.sectionTitle}>Learn More</Text>
-              <Text style={styles.sectionDescription}>
-                Read the docs to discover what to do next:
-              </Text>
-            </View>
-            <LearnMoreLinks />
-          </View>
-        </ScrollView>
-      </SafeAreaView>
-    </>
-  );
-};
+const EVENT_AZURE_NOTIFICATION_HUB_REGISTERED         = 'azureNotificationHubRegistered';
+const EVENT_AZURE_NOTIFICATION_HUB_REGISTERED_ERROR   = 'azureNotificationHubRegisteredError';
+const EVENT_REMOTE_NOTIFICATION_RECEIVED              = 'remoteNotificationReceived';
+
+const connectionString                                = 'Endpoint=sb://rn-anh.servicebus.windows.net/;SharedAccessKeyName=DefaultFullSharedAccessSignature;SharedAccessKey=12345';
+const hubName                                         = 'azurenotificationhub';
+const senderID                                        = '12345';
+const tags                                            = [];
+const channelName                                     = 'Channel Name';
+const channelImportance                               = 3;
+const channelShowBadge                                = true;
+const channelEnableLights                             = true;
+const channelEnableVibration                          = true;
+const template                                        = '{\"data\":{\"message\":\"$(message)\"}}';
+const templateName                                    = 'Template Name';
+
+export default class App extends Component {
+  constructor(props) {
+    super(props);
+    PushNotificationEmitter.addListener(EVENT_REMOTE_NOTIFICATION_RECEIVED, this._onRemoteNotification);
+  }
+
+  register() {
+    PushNotificationEmitter.addListener(EVENT_AZURE_NOTIFICATION_HUB_REGISTERED, this._onAzureNotificationHubRegistered);
+    PushNotificationEmitter.addListener(EVENT_AZURE_NOTIFICATION_HUB_REGISTERED_ERROR, this._onAzureNotificationHubRegisteredError);
+
+    NotificationHub.register({
+      connectionString,
+      hubName,
+      senderID,
+      tags,
+      channelName,
+      channelImportance,
+      channelShowBadge,
+      channelEnableLights,
+      channelEnableVibration
+    })
+    .then((res) => console.warn(res))
+    .catch(reason => console.warn(reason));
+  }
+
+  registerTemplate() {
+    PushNotificationEmitter.addListener(EVENT_AZURE_NOTIFICATION_HUB_REGISTERED, this._onAzureNotificationHubRegistered);
+    PushNotificationEmitter.addListener(EVENT_AZURE_NOTIFICATION_HUB_REGISTERED_ERROR, this._onAzureNotificationHubRegisteredError);
+
+    NotificationHub.registerTemplate({
+      connectionString,
+      hubName,
+      senderID,
+      template,
+      templateName,
+      tags,
+      channelName,
+      channelImportance,
+      channelShowBadge,
+      channelEnableLights,
+      channelEnableVibration
+    })
+    .then((res) => console.warn(res))
+    .catch(reason => console.warn(reason));
+  }
+
+  getInitialNotification() {
+    NotificationHub.getInitialNotification()
+    .then((res) => console.warn(res))
+    .catch(reason => console.warn(reason));
+  }
+
+  getUUID() {
+    NotificationHub.getUUID(false)
+    .then((res) => console.warn(res))
+    .catch(reason => console.warn(reason));
+  }
+
+  isNotificationEnabledOnOSLevel() {
+    NotificationHub.isNotificationEnabledOnOSLevel()
+    .then((res) => console.warn(res))
+    .catch(reason => console.warn(reason));
+  }
+
+  unregister() {
+    NotificationHub.unregister()
+    .then((res) => console.warn(res))
+    .catch(reason => console.warn(reason));
+  }
+
+  unregisterTemplate() {
+    NotificationHub.unregisterTemplate(templateName)
+    .then((res) => console.warn(res))
+    .catch(reason => console.warn(reason));
+  }
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <TouchableOpacity onPress={this.register.bind(this)}>
+         <View style={styles.button}>
+           <Text style={styles.buttonText}>
+             Register
+           </Text>
+         </View>
+       </TouchableOpacity>
+       <TouchableOpacity onPress={this.registerTemplate.bind(this)}>
+         <View style={styles.button}>
+           <Text style={styles.buttonText}>
+             Register Template
+           </Text>
+         </View>
+       </TouchableOpacity>
+       <TouchableOpacity onPress={this.getInitialNotification.bind(this)}>
+         <View style={styles.button}>
+           <Text style={styles.buttonText}>
+            Get initial notification
+           </Text>
+         </View>
+       </TouchableOpacity>
+       <TouchableOpacity onPress={this.getUUID.bind(this)}>
+         <View style={styles.button}>
+           <Text style={styles.buttonText}>
+            Get UUID
+           </Text>
+         </View>
+       </TouchableOpacity>
+       <TouchableOpacity onPress={this.isNotificationEnabledOnOSLevel.bind(this)}>
+         <View style={styles.button}>
+           <Text style={styles.buttonText}>
+            Check if notification is enabled
+           </Text>
+         </View>
+       </TouchableOpacity>
+       <TouchableOpacity onPress={this.unregister.bind(this)}>
+         <View style={styles.button}>
+           <Text style={styles.buttonText}>
+             Unregister
+           </Text>
+         </View>
+       </TouchableOpacity>
+       <TouchableOpacity onPress={this.unregisterTemplate.bind(this)}>
+         <View style={styles.button}>
+           <Text style={styles.buttonText}>
+             Unregister Template
+           </Text>
+         </View>
+       </TouchableOpacity>
+      </View>
+    );
+  }
+
+  _onAzureNotificationHubRegistered(registrationID) {
+    console.warn('RegistrationID: ' + registrationID);
+  }
+
+  _onAzureNotificationHubRegisteredError(error) {
+    console.warn('Error: ' + error);
+  }
+
+  _onRemoteNotification(notification) {
+    console.warn(notification);
+  }
+}
 
 const styles = StyleSheet.create({
-  scrollView: {
-    backgroundColor: Colors.lighter,
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F5FCFF',
   },
-  engine: {
-    position: 'absolute',
-    right: 0,
+  welcome: {
+    fontSize: 20,
+    textAlign: 'center',
+    margin: 10,
   },
-  body: {
-    backgroundColor: Colors.white,
-  },
-  sectionContainer: {
-    marginTop: 32,
-    paddingHorizontal: 24,
-  },
-  sectionTitle: {
-    fontSize: 24,
-    fontWeight: '600',
-    color: Colors.black,
-  },
-  sectionDescription: {
-    marginTop: 8,
-    fontSize: 18,
-    fontWeight: '400',
-    color: Colors.dark,
-  },
-  highlight: {
-    fontWeight: '700',
-  },
-  footer: {
-    color: Colors.dark,
-    fontSize: 12,
-    fontWeight: '600',
-    padding: 4,
-    paddingRight: 12,
-    textAlign: 'right',
+  instructions: {
+    textAlign: 'center',
+    color: '#333333',
+    marginBottom: 5,
   },
 });
-
-export default App;

--- a/sample/android/app/src/test/java/com/reactnativeazurenotificationhubsample/ReactNativeNotificationHubModuleTest.java
+++ b/sample/android/app/src/test/java/com/reactnativeazurenotificationhubsample/ReactNativeNotificationHubModuleTest.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
 
+import androidx.annotation.RequiresPermission;
+import androidx.core.app.NotificationManagerCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import org.junit.Assert;
@@ -14,6 +16,7 @@ import org.junit.Test;
 
 import static com.azure.reactnative.notificationhub.ReactNativeConstants.*;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -35,11 +38,13 @@ import com.azure.reactnative.notificationhub.ReactNativeNotificationHubModule;
 import com.azure.reactnative.notificationhub.ReactNativeNotificationsHandler;
 import com.azure.reactnative.notificationhub.ReactNativeRegistrationIntentService;
 import com.azure.reactnative.notificationhub.ReactNativeUtil;
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.microsoft.windowsazure.messaging.NotificationHub;
@@ -54,7 +59,9 @@ import com.microsoft.windowsazure.messaging.NotificationHub;
         ReactNativeUtil.class,
         ReactNativeNotificationsHandler.class,
         ReactNativeRegistrationIntentService.class,
-        GoogleApiAvailability.class
+        GoogleApiAvailability.class,
+        Arguments.class,
+        NotificationManagerCompat.class
 })
 public class ReactNativeNotificationHubModuleTest {
     @Mock
@@ -81,6 +88,9 @@ public class ReactNativeNotificationHubModuleTest {
     @Mock
     NotificationHub mNotificationHub;
 
+    @Mock
+    WritableMap mRes;
+
     ReactNativeNotificationHubModule mHubModule;
 
     @Before
@@ -102,6 +112,9 @@ public class ReactNativeNotificationHubModuleTest {
         PowerMockito.mockStatic(ReactNativeRegistrationIntentService.class);
         PowerMockito.mockStatic(GoogleApiAvailability.class);
         when(GoogleApiAvailability.getInstance()).thenReturn(mGoogleApiAvailability);
+        PowerMockito.mockStatic(Arguments.class);
+        when(Arguments.createMap()).thenReturn(mRes);
+        PowerMockito.mockStatic(NotificationManagerCompat.class);
 
         mHubModule = new ReactNativeNotificationHubModule(mReactApplicationContext);
     }
@@ -253,6 +266,39 @@ public class ReactNativeNotificationHubModuleTest {
     }
 
     @Test
+    public void testRegisterGenUUID() {
+        when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn(KEY_REGISTRATION_CONNECTIONSTRING);
+        when(mConfig.getString(KEY_REGISTRATION_HUBNAME)).thenReturn(KEY_REGISTRATION_HUBNAME);
+        when(mConfig.getString(KEY_REGISTRATION_SENDERID)).thenReturn(KEY_REGISTRATION_SENDERID);
+        when(ReactNativeUtil.genUUID()).thenReturn(PowerMockito.mock(String.class));
+
+        mHubModule.register(mConfig, mPromise);
+
+        verify(mNotificationHubUtil, times(1)).getUUID(any(ReactContext.class));
+        verify(mNotificationHubUtil, times(1)).setUUID(
+                any(ReactContext.class), anyString());
+        PowerMockito.verifyStatic((ReactNativeUtil.class));
+        ReactNativeUtil.genUUID();
+    }
+
+    @Test
+    public void testRegisterExistingUUID() {
+        when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn(KEY_REGISTRATION_CONNECTIONSTRING);
+        when(mConfig.getString(KEY_REGISTRATION_HUBNAME)).thenReturn(KEY_REGISTRATION_HUBNAME);
+        when(mConfig.getString(KEY_REGISTRATION_SENDERID)).thenReturn(KEY_REGISTRATION_SENDERID);
+        when(mNotificationHubUtil.getUUID(any(ReactContext.class))).thenReturn(
+                PowerMockito.mock(String.class));
+
+        mHubModule.register(mConfig, mPromise);
+
+        verify(mNotificationHubUtil, times(1)).getUUID(any(ReactContext.class));
+        verify(mNotificationHubUtil, times(0)).setUUID(
+                any(ReactContext.class), anyString());
+        PowerMockito.verifyStatic((ReactNativeUtil.class), times(0));
+        ReactNativeUtil.genUUID();
+    }
+
+    @Test
     public void testRegisterSuccessfully() {
         final String connectionString = "Connection String";
         final String hubName = "Hub Name";
@@ -278,8 +324,12 @@ public class ReactNativeNotificationHubModuleTest {
                 any(ReactContext.class), eq(hubName));
         verify(mNotificationHubUtil, times(1)).setSenderID(
                 any(ReactContext.class), eq(senderID));
+        verify(mNotificationHubUtil, times(1)).setTemplated(
+                any(ReactContext.class), eq(false));
         verify(mNotificationHubUtil, times(1)).setTags(
                 any(ReactContext.class), eq(tags));
+        verify(mRes, times(1)).putString(eq(KEY_PROMISE_RESOLVE_UUID), any());
+        verify(mPromise, times(1)).resolve(mRes);
         verify(mPromise, times(0)).reject(anyString(), anyString());
 
         PowerMockito.verifyStatic(ReactNativeRegistrationIntentService.class);
@@ -319,14 +369,17 @@ public class ReactNativeNotificationHubModuleTest {
 
         mHubModule.unregister(mPromise);
 
-        verify(mPromise, times(0)).reject(anyString(), anyString());
         verify(mNotificationHub, times(1)).unregister();
         verify(mNotificationHubUtil, times(1)).setRegistrationID(
                 any(ReactContext.class), eq(null));
+        verify(mNotificationHubUtil, times(1)).setUUID(
+                any(ReactContext.class), eq(null));
+        verify(mPromise, times(0)).reject(anyString(), anyString());
+        verify(mPromise, times(1)).resolve(AZURE_NOTIFICATION_HUB_UNREGISTERED);
     }
 
     @Test
-    public void testUnregisterNoRegistration() throws Exception {
+    public void testUnregisterNoRegistration() {
         when(mNotificationHubUtil.getConnectionString(any(ReactContext.class))).thenReturn("Connection String");
         when(mNotificationHubUtil.getHubName(any(ReactContext.class))).thenReturn("Hub Name");
         when(mNotificationHubUtil.getRegistrationID(any(ReactContext.class))).thenReturn(null);
@@ -356,6 +409,282 @@ public class ReactNativeNotificationHubModuleTest {
         verify(mPromise, times(1)).reject(
                 ERROR_NOTIFICATION_HUB,
                 unhandledException);
+    }
+
+    @Test
+    public void testRegisterTemplateMissingTemplateName() {
+        when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn("Connection String");
+        when(mConfig.getString(KEY_REGISTRATION_HUBNAME)).thenReturn("Hub Name");
+        when(mConfig.getString(KEY_REGISTRATION_SENDERID)).thenReturn("Connection String");
+
+        mHubModule.registerTemplate(mConfig, mPromise);
+
+        verify(mPromise, times(1)).reject(
+                ERROR_INVALID_ARGUMENTS,
+                ERROR_INVALID_TEMPLATE_NAME);
+    }
+
+    @Test
+    public void testRegisterTemplateMissingTemplate() {
+        when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn("Connection String");
+        when(mConfig.getString(KEY_REGISTRATION_HUBNAME)).thenReturn("Hub Name");
+        when(mConfig.getString(KEY_REGISTRATION_SENDERID)).thenReturn("Connection String");
+        when(mConfig.getString(KEY_REGISTRATION_TEMPLATENAME)).thenReturn("Template Name");
+
+        mHubModule.registerTemplate(mConfig, mPromise);
+
+        verify(mPromise, times(1)).reject(
+                ERROR_INVALID_ARGUMENTS,
+                ERROR_INVALID_TEMPLATE);
+    }
+
+    @Test
+    public void testRegisterTemplateSuccessfully() {
+        final String connectionString = "Connection String";
+        final String hubName = "Hub Name";
+        final String senderID = "Sender ID";
+        final String templateName = "Template Name";
+        final String template = "Template";
+        final String[] tags = { "Tag" };
+
+        when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn(connectionString);
+        when(mConfig.getString(KEY_REGISTRATION_HUBNAME)).thenReturn(hubName);
+        when(mConfig.getString(KEY_REGISTRATION_SENDERID)).thenReturn(senderID);
+        when(mConfig.getString(KEY_REGISTRATION_TEMPLATENAME)).thenReturn(templateName);
+        when(mConfig.getString(KEY_REGISTRATION_TEMPLATE)).thenReturn(template);
+        when(mConfig.hasKey(KEY_REGISTRATION_TAGS)).thenReturn(true);
+        when(mConfig.isNull(KEY_REGISTRATION_TAGS)).thenReturn(false);
+        when(mConfig.getArray(KEY_REGISTRATION_TAGS)).thenReturn(mTags);
+        when(mTags.size()).thenReturn(1);
+        when(mTags.getString(0)).thenReturn(tags[0]);
+        when(mGoogleApiAvailability.isGooglePlayServicesAvailable(any())).thenReturn(
+                ConnectionResult.SUCCESS);
+
+        mHubModule.registerTemplate(mConfig, mPromise);
+
+        verify(mNotificationHubUtil, times(1)).setConnectionString(
+                any(ReactContext.class), eq(connectionString));
+        verify(mNotificationHubUtil, times(1)).setHubName(
+                any(ReactContext.class), eq(hubName));
+        verify(mNotificationHubUtil, times(1)).setSenderID(
+                any(ReactContext.class), eq(senderID));
+        verify(mNotificationHubUtil, times(1)).setTemplateName(
+                any(ReactContext.class), eq(templateName));
+        verify(mNotificationHubUtil, times(1)).setTemplate(
+                any(ReactContext.class), eq(template));
+        verify(mNotificationHubUtil, times(1)).setTemplated(
+                any(ReactContext.class), eq(true));
+        verify(mNotificationHubUtil, times(1)).setTags(
+                any(ReactContext.class), eq(tags));
+        verify(mRes, times(1)).putString(eq(KEY_PROMISE_RESOLVE_UUID), any());
+        verify(mPromise, times(1)).resolve(mRes);
+        verify(mPromise, times(0)).reject(anyString(), anyString());
+
+        PowerMockito.verifyStatic(ReactNativeRegistrationIntentService.class);
+        ReactNativeRegistrationIntentService.enqueueWork(eq(mReactApplicationContext), any(Intent.class));
+    }
+
+    @Test
+    public void testRegisterTemplateFailed() {
+        final String[] tags = { "Tag" };
+
+        when(mConfig.getString(KEY_REGISTRATION_CONNECTIONSTRING)).thenReturn("Connection String");
+        when(mConfig.getString(KEY_REGISTRATION_HUBNAME)).thenReturn("Hub Name");
+        when(mConfig.getString(KEY_REGISTRATION_SENDERID)).thenReturn("Sender ID");
+        when(mConfig.getString(KEY_REGISTRATION_TEMPLATENAME)).thenReturn("Template Name");
+        when(mConfig.getString(KEY_REGISTRATION_TEMPLATE)).thenReturn("Template");
+        when(mConfig.hasKey(KEY_REGISTRATION_TAGS)).thenReturn(true);
+        when(mConfig.isNull(KEY_REGISTRATION_TAGS)).thenReturn(false);
+        when(mConfig.getArray(KEY_REGISTRATION_TAGS)).thenReturn(mTags);
+        when(mTags.size()).thenReturn(1);
+        when(mTags.getString(0)).thenReturn(tags[0]);
+        when(mGoogleApiAvailability.isGooglePlayServicesAvailable(any())).thenReturn(
+                ConnectionResult.INTERNAL_ERROR);
+        when(mGoogleApiAvailability.isUserResolvableError(anyInt())).thenReturn(false);
+
+        mHubModule.registerTemplate(mConfig, mPromise);
+
+        verify(mPromise, times(1)).reject(
+                ERROR_PLAY_SERVICES,
+                ERROR_PLAY_SERVICES_UNSUPPORTED);
+    }
+
+    @Test
+    public void testUnregisterTemplateSuccessfully() throws Exception {
+        final String templateName = "Template Name";
+
+        when(mNotificationHubUtil.getConnectionString(any(ReactContext.class))).thenReturn("Connection String");
+        when(mNotificationHubUtil.getHubName(any(ReactContext.class))).thenReturn("Hub Name");
+        when(mNotificationHubUtil.getRegistrationID(any(ReactContext.class))).thenReturn("registrationId");
+        when(ReactNativeUtil.createNotificationHub(
+                anyString(), anyString(), any(ReactContext.class))).thenReturn(mNotificationHub);
+
+        mHubModule.unregisterTemplate(templateName, mPromise);
+
+        verify(mNotificationHub, times(1)).unregisterTemplate(templateName);
+        verify(mNotificationHubUtil, times(1)).setRegistrationID(
+                any(ReactContext.class), eq(null));
+        verify(mNotificationHubUtil, times(1)).setUUID(
+                any(ReactContext.class), eq(null));
+        verify(mPromise, times(0)).reject(anyString(), anyString());
+        verify(mPromise, times(1)).resolve(AZURE_NOTIFICATION_HUB_UNREGISTERED);
+    }
+
+    @Test
+    public void testUnregisterTemplateNoRegistration() {
+        when(mNotificationHubUtil.getConnectionString(any(ReactContext.class))).thenReturn("Connection String");
+        when(mNotificationHubUtil.getHubName(any(ReactContext.class))).thenReturn("Hub Name");
+        when(mNotificationHubUtil.getRegistrationID(any(ReactContext.class))).thenReturn(null);
+        when(ReactNativeUtil.createNotificationHub(
+                anyString(), anyString(), any(ReactContext.class))).thenReturn(mNotificationHub);
+
+        mHubModule.unregisterTemplate("Template Name", mPromise);
+
+        verify(mPromise, times(1)).reject(
+                ERROR_NOT_REGISTERED,
+                ERROR_NOT_REGISTERED_DESC);
+    }
+
+    @Test
+    public void testUnregisterTemplateThrowException() throws Exception {
+        final String templateName = "Template Name";
+        final Exception unhandledException = new Exception("Unhandled exception");
+
+        when(mNotificationHubUtil.getConnectionString(any(ReactContext.class))).thenReturn("Connection String");
+        when(mNotificationHubUtil.getHubName(any(ReactContext.class))).thenReturn("Hub Name");
+        when(mNotificationHubUtil.getRegistrationID(any(ReactContext.class))).thenReturn("registrationId");
+        when(ReactNativeUtil.createNotificationHub(
+                anyString(), anyString(), any(ReactContext.class))).thenReturn(mNotificationHub);
+        doThrow(unhandledException).when(mNotificationHub).unregisterTemplate(templateName);
+
+        mHubModule.unregisterTemplate(templateName, mPromise);
+
+        verify(mPromise, times(1)).reject(
+                ERROR_NOTIFICATION_HUB,
+                unhandledException);
+    }
+
+    @Test
+    public void testGetInitialNotificationNullActivity() {
+        when(mReactApplicationContext.getCurrentActivity()).thenReturn(null);
+
+        mHubModule.getInitialNotification(mPromise);
+
+        verify(mPromise, times(1)).reject(
+                ERROR_GET_INIT_NOTIFICATION,
+                ERROR_ACTIVITY_IS_NULL);
+    }
+
+    @Test
+    public void testGetInitialNotificationNullIntent() {
+        Activity activity = PowerMockito.mock(Activity.class);
+        when(mReactApplicationContext.getCurrentActivity()).thenReturn(activity);
+        when(activity.getIntent()).thenReturn(null);
+
+        mHubModule.getInitialNotification(mPromise);
+
+        verify(mPromise, times(1)).reject(
+                ERROR_GET_INIT_NOTIFICATION,
+                ERROR_ACTIVITY_INTENT_IS_NULL);
+    }
+
+    @Test
+    public void testGetInitialNotificationNullIntentAction() {
+        Activity activity = PowerMockito.mock(Activity.class);
+        when(mReactApplicationContext.getCurrentActivity()).thenReturn(activity);
+        Intent intent = PowerMockito.mock(Intent.class);
+        when(activity.getIntent()).thenReturn(intent);
+        when(intent.getAction()).thenReturn(null);
+
+        mHubModule.getInitialNotification(mPromise);
+
+        verify(mPromise, times(1)).reject(
+                ERROR_GET_INIT_NOTIFICATION,
+                ERROR_ACTIVITY_INTENT_IS_NULL);
+    }
+
+    @Test
+    public void testGetInitialNotificationNullIntentExtras() {
+        Activity activity = PowerMockito.mock(Activity.class);
+        when(mReactApplicationContext.getCurrentActivity()).thenReturn(activity);
+        Intent intent = PowerMockito.mock(Intent.class);
+        when(activity.getIntent()).thenReturn(intent);
+        when(intent.getAction()).thenReturn(PowerMockito.mock(String.class));
+        when(intent.getExtras()).thenReturn(null);
+
+        mHubModule.getInitialNotification(mPromise);
+
+        verify(mPromise, times(1)).reject(
+                ERROR_GET_INIT_NOTIFICATION,
+                ERROR_INTENT_EXTRAS_IS_NULL);
+    }
+
+    @Test
+    public void testGetInitialNotification() {
+        Activity activity = PowerMockito.mock(Activity.class);
+        when(mReactApplicationContext.getCurrentActivity()).thenReturn(activity);
+        Intent intent = PowerMockito.mock(Intent.class);
+        when(activity.getIntent()).thenReturn(intent);
+        when(intent.getAction()).thenReturn(PowerMockito.mock(String.class));
+        when(intent.getExtras()).thenReturn(PowerMockito.mock(Bundle.class));
+        WritableMap map = PowerMockito.mock(WritableMap.class);
+        when(ReactNativeUtil.convertBundleToMap(any())).thenReturn(map);
+
+        mHubModule.getInitialNotification(mPromise);
+
+        verify(mPromise, times(1)).resolve(map);
+    }
+
+    @Test
+    public void testGetUUIDNoUUIDNoAutoGen() {
+        when(mNotificationHubUtil.getUUID(mReactApplicationContext)).thenReturn(null);
+
+        mHubModule.getUUID(false, mPromise);
+
+        verify(mPromise, times(1)).reject(
+                ERROR_GET_UUID,
+                ERROR_NO_UUID_SET);
+    }
+
+    @Test
+    public void testGetUUIDNoUUIDAutoGen() {
+        final String uuid = "uuid";
+
+        when(mNotificationHubUtil.getUUID(mReactApplicationContext)).thenReturn(null);
+        when(ReactNativeUtil.genUUID()).thenReturn(uuid);
+
+        mHubModule.getUUID(true, mPromise);
+
+        verify(mNotificationHubUtil, times(1)).setUUID(
+                mReactApplicationContext, uuid);
+        verify(mPromise, times(1)).resolve(uuid);
+    }
+
+    @Test
+    public void testGetUUID() {
+        final String uuid = "uuid";
+
+        when(mNotificationHubUtil.getUUID(mReactApplicationContext)).thenReturn(uuid);
+
+        mHubModule.getUUID(true, mPromise);
+
+        PowerMockito.verifyStatic(ReactNativeUtil.class, times(0));
+        ReactNativeUtil.genUUID();
+        verify(mPromise, times(1)).resolve(uuid);
+    }
+
+    @Test
+    public void testIsNotificationEnabledOnOSLevel() {
+        final boolean areNotificationsEnabled = true;
+
+        NotificationManagerCompat manager = PowerMockito.mock(NotificationManagerCompat.class);
+        when(NotificationManagerCompat.from(mReactApplicationContext)).thenReturn(manager);
+        when(manager.areNotificationsEnabled()).thenReturn(areNotificationsEnabled);
+
+        mHubModule.isNotificationEnabledOnOSLevel(mPromise);
+
+        verify(manager, times(1)).areNotificationsEnabled();
+        verify(mPromise, times(1)).resolve(areNotificationsEnabled);
     }
 
     @Test

--- a/sample/android/app/src/test/java/com/reactnativeazurenotificationhubsample/ReactNativeNotificationHubUtilTest.java
+++ b/sample/android/app/src/test/java/com/reactnativeazurenotificationhubsample/ReactNativeNotificationHubUtilTest.java
@@ -323,4 +323,80 @@ public class ReactNativeNotificationHubUtilTest {
 
         verify(mSharedPreferences, times(1)).contains(KEY_FOR_PREFS_CHANNELENABLELIGHTS);
     }
+
+    @Test
+    public void testGetTemplateName() {
+        mHubUtil.getTemplateName(mReactApplicationContext);
+
+        verify(mSharedPreferences, times(1)).getString(
+                KEY_FOR_PREFS_TEMPLATENAME, null);
+    }
+
+    @Test
+    public void testSetTemplateName() {
+        final String templateName = "Template Name";
+
+        mHubUtil.setTemplateName(mReactApplicationContext, templateName);
+
+        verify(mEditor, times(1)).putString(
+                KEY_FOR_PREFS_TEMPLATENAME, templateName);
+        verify(mEditor, times(1)).apply();
+    }
+
+    @Test
+    public void testGetTemplate() {
+        mHubUtil.getTemplate(mReactApplicationContext);
+
+        verify(mSharedPreferences, times(1)).getString(
+                KEY_FOR_PREFS_TEMPLATE, null);
+    }
+
+    @Test
+    public void testSetTemplate() {
+        final String template = "Template";
+
+        mHubUtil.setTemplate(mReactApplicationContext, template);
+
+        verify(mEditor, times(1)).putString(
+                KEY_FOR_PREFS_TEMPLATE, template);
+        verify(mEditor, times(1)).apply();
+    }
+
+    @Test
+    public void testIsTemplated() {
+        mHubUtil.isTemplated(mReactApplicationContext);
+
+        verify(mSharedPreferences, times(1)).getBoolean(
+                KEY_FOR_PREFS_ISTEMPLATE, false);
+    }
+
+    @Test
+    public void testSetTemplated() {
+        final boolean isTemplated = true;
+
+        mHubUtil.setTemplated(mReactApplicationContext, isTemplated);
+
+        verify(mEditor, times(1)).putBoolean(
+                KEY_FOR_PREFS_ISTEMPLATE, isTemplated);
+        verify(mEditor, times(1)).apply();
+    }
+
+    @Test
+    public void testGetUUID() {
+        mHubUtil.getUUID(mReactApplicationContext);
+
+        verify(mSharedPreferences, times(1)).getString(
+                KEY_FOR_PREFS_UUID, null);
+    }
+
+    @Test
+    public void testSetUUID() {
+        final String uuid = "uuid";
+
+        mHubUtil.setUUID(mReactApplicationContext, uuid);
+
+        verify(mEditor, times(1)).putString(
+                KEY_FOR_PREFS_UUID, uuid);
+        verify(mEditor, times(1)).apply();
+    }
 }

--- a/sample/ios/ReactNativeAzureNotificationHubSample.xcodeproj/project.pbxproj
+++ b/sample/ios/ReactNativeAzureNotificationHubSample.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		2D02E4901E0B4A5D006451C7 /* ReactNativeAzureNotificationHubSample-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ReactNativeAzureNotificationHubSample-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3AAB39D4BDBE7F53EC74C4C4 /* libPods-ReactNativeAzureNotificationHubSample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ReactNativeAzureNotificationHubSample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B18387DF86E68D789995173 /* Pods-ReactNativeAzureNotificationHubSample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactNativeAzureNotificationHubSample.release.xcconfig"; path = "Target Support Files/Pods-ReactNativeAzureNotificationHubSample/Pods-ReactNativeAzureNotificationHubSample.release.xcconfig"; sourceTree = "<group>"; };
+		45454162242451A2003F4618 /* ReactNativeAzureNotificationHubSample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = ReactNativeAzureNotificationHubSample.entitlements; path = ReactNativeAzureNotificationHubSample/ReactNativeAzureNotificationHubSample.entitlements; sourceTree = "<group>"; };
 		45E30B45240821F000A339F1 /* RCTAzureNotificationHubManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.objc; path = RCTAzureNotificationHubManagerTests.m; sourceTree = "<group>"; tabWidth = 4; };
 		45E30B46240821F000A339F1 /* RCTAzureNotificationHubUtilTests.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.objc; path = RCTAzureNotificationHubUtilTests.m; sourceTree = "<group>"; tabWidth = 4; };
 		45E30B47240821F100A339F1 /* RCTAzureNotificationHandlerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.objc; path = RCTAzureNotificationHandlerTests.m; sourceTree = "<group>"; tabWidth = 4; };
@@ -120,6 +121,7 @@
 		13B07FAE1A68108700A75B9A /* ReactNativeAzureNotificationHubSample */ = {
 			isa = PBXGroup;
 			children = (
+				45454162242451A2003F4618 /* ReactNativeAzureNotificationHubSample.entitlements */,
 				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				13B07FB01A68108700A75B9A /* AppDelegate.m */,
@@ -589,6 +591,7 @@
 			baseConfigurationReference = 2351567499705FB80A85A312 /* Pods-ReactNativeAzureNotificationHubSample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = ReactNativeAzureNotificationHubSample/ReactNativeAzureNotificationHubSample.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = NO;
 				INFOPLIST_FILE = ReactNativeAzureNotificationHubSample/Info.plist;
@@ -609,6 +612,7 @@
 			baseConfigurationReference = 3B18387DF86E68D789995173 /* Pods-ReactNativeAzureNotificationHubSample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = ReactNativeAzureNotificationHubSample/ReactNativeAzureNotificationHubSample.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = ReactNativeAzureNotificationHubSample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/sample/ios/ReactNativeAzureNotificationHubSample/AppDelegate.m
+++ b/sample/ios/ReactNativeAzureNotificationHubSample/AppDelegate.m
@@ -28,6 +28,10 @@
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
+
+  // Registering for local notifications
+  [[UNUserNotificationCenter currentNotificationCenter] setDelegate:self];
+
   return YES;
 }
 
@@ -40,34 +44,34 @@
 #endif
 }
 
-// Required to register for notifications
-- (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
-{
-  [RCTAzureNotificationHubManager didRegisterUserNotificationSettings:notificationSettings];
-}
-
-// Required for the register event.
+// Invoked when the app successfully registered with Apple Push Notification service (APNs).
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {
   [RCTAzureNotificationHubManager didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
 }
 
-// Required for the registrationError event.
+// Invoked when APNs cannot successfully complete the registration process.
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
 {
   [RCTAzureNotificationHubManager didFailToRegisterForRemoteNotificationsWithError:error];
 }
 
-// Required for the notification event.
-- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification
+// Invoked when a remote notification arrived and there is data to be fetched.
+- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo
+                                                       fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler
 {
-  [RCTAzureNotificationHubManager didReceiveRemoteNotification:notification];
+  [RCTAzureNotificationHubManager didReceiveRemoteNotification:userInfo
+                                        fetchCompletionHandler:completionHandler];
 }
 
-// Required for the localNotification event.
-- (void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification
+// Invoked when a notification arrived while the app was running in the foreground.
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+       willPresentNotification:(UNNotification *)notification
+         withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler
 {
-  [RCTAzureNotificationHubManager didReceiveLocalNotification:notification];
+  [RCTAzureNotificationHubManager userNotificationCenter:center
+                                 willPresentNotification:notification
+                                   withCompletionHandler:completionHandler];
 }
 
 @end

--- a/sample/ios/ReactNativeAzureNotificationHubSample/ReactNativeAzureNotificationHubSample.entitlements
+++ b/sample/ios/ReactNativeAzureNotificationHubSample/ReactNativeAzureNotificationHubSample.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>


### PR DESCRIPTION
Integrating several features and improvements from [Mixer](https://github.com/mixer/react-native-azurenotificationhub)

**Android**

- Support Azure Notification Hub templates #102 
- Add new APIs: `getInitialNotification`, `isNotificationEnabledOnOSLevel`, `getUUID` #126 

**iOS**

- Support Azure Notification Hub templates #102 
- Replace UIUserNotificationSettings deprecated APIs #128 
