### PR TITLE
add category property for iOS remote notification

### DIFF
--- a/index.ios.d.ts
+++ b/index.ios.d.ts
@@ -94,6 +94,7 @@ declare class IOSNotification {
     private _alert: string | IOSNotification.IOSAlert;
     private _sound: string;
     private _badgeCount: number;
+    private _category: string;
 
     static presentLocalNotification(details: IOSNotification.LocalNotification): void;
     static scheduleLocalNotification(details: IOSNotification.FutureLocalNotification): void;
@@ -126,6 +127,7 @@ declare class IOSNotification {
     public getMessage(): string | IOSNotification.IOSAlert;
     public getSound(): string;
     public getBadgeCount(): number;
+    public getCategory(): string;
     public getData(): any;
 }
 

--- a/ios/AzureNotificationHubIOS.js
+++ b/ios/AzureNotificationHubIOS.js
@@ -124,6 +124,7 @@ class AzureNotificationHubIOS {
   _alert: string | Object;
   _sound: string;
   _badgeCount: number;
+  _category: string;
 
   /**
    * Schedules the localNotification for immediate presentation.
@@ -216,7 +217,7 @@ class AzureNotificationHubIOS {
    */
   static addEventListener(type: PushNotificationEventName, handler: Function) {
     invariant(
-      type === 'notification' || type === 'register' || type === 'registrationError' || 
+      type === 'notification' || type === 'register' || type === 'registrationError' ||
       type === 'registerAzureNotificationHub' || type === 'azureNotificationHubRegistrationError' || type === 'localNotification',
       'AzureNotificationHubIOS only supports `notification`, `register`, `registrationError`, `registerAzureNotificationHub`, `azureNotificationHubRegistrationError` and `localNotification` events'
     );
@@ -273,7 +274,7 @@ class AzureNotificationHubIOS {
    */
   static removeEventListener(type: PushNotificationEventName, handler: Function) {
     invariant(
-      type === 'notification' || type === 'register' || type === 'registrationError' || 
+      type === 'notification' || type === 'register' || type === 'registrationError' ||
       type === 'registerAzureNotificationHub' || type === 'azureNotificationHubRegistrationError' || type === 'localNotification',
       'AzureNotificationHubIOS only supports `notification`, `register`, `registrationError`, `registerAzureNotificationHub`, `azureNotificationHubRegistrationError` and `localNotification` events'
     );
@@ -400,6 +401,7 @@ class AzureNotificationHubIOS {
           this._alert = notifVal.alert;
           this._sound = notifVal.sound;
           this._badgeCount = notifVal.badge;
+          this._category = notifVal.category;
         } else {
           this._data[notifKey] = notifVal;
         }
@@ -440,6 +442,13 @@ class AzureNotificationHubIOS {
    */
   getBadgeCount(): ?number {
     return this._badgeCount;
+  }
+
+  /**
+   * Gets the category from the `aps` object
+   */
+  getCategory(): ?string {
+    return this._category;
   }
 
   /**


### PR DESCRIPTION
I noticed that on ios for remote notifications there was no way to get the category when the app is in background and then we open the notification, so I added it.