### PR TITLE
Use mavenCentral instead of bintray

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,12 +25,10 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation 'com.google.firebase:firebase-messaging:17.6.0'
     implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.microsoft.azure:notification-hubs-android-sdk:0.6@aar'
+    implementation 'com.microsoft.azure:notification-hubs-android-sdk:0.6'
 }
 
 repositories {
-    maven {
-        url "http://dl.bintray.com/microsoftazuremobile/SDK"
-    }
+    mavenCentral()
 }
 


### PR DESCRIPTION
Since the bintray url is down and only returns 502 a switch to mavenCentral is required.